### PR TITLE
feat(ui): add scroll support with PageUp/PageDown and mouse/trackpad scrolling

### DIFF
--- a/packages/gg-coding-agent/src/ui/App.tsx
+++ b/packages/gg-coding-agent/src/ui/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useCallback, useEffect, useMemo } from "react";
-import { Box, Text, Static, useStdout } from "ink";
+import { Box, Text, Static, useStdout, useInput } from "ink";
 import { useTerminalSize } from "./hooks/useTerminalSize.js";
 import crypto from "node:crypto";
 import type {
@@ -28,6 +28,9 @@ import { Banner } from "./components/Banner.js";
 import { ShimmerLine } from "./components/ShimmerLine.js";
 import { ModelSelector } from "./components/ModelSelector.js";
 import { BackgroundTasksBar } from "./components/BackgroundTasksBar.js";
+import { ScrollIndicator } from "./components/ScrollIndicator.js";
+import { useContentScroll } from "./hooks/useContentScroll.js";
+import { useMouseScroll } from "./hooks/useMouseScroll.js";
 import type { SlashCommandInfo } from "./components/SlashCommandMenu.js";
 import type { ProcessManager, BackgroundProcess } from "../core/process-manager.js";
 import { useTheme } from "./theme/theme.js";
@@ -258,6 +261,7 @@ export function App(props: AppProps) {
   }, [isRestoredSession, props.initialHistory]);
   // Items from the current/last turn — rendered in the live area so they stay visible
   const [liveItems, setLiveItems] = useState<CompletedItem[]>([]);
+  const contentScroll = useContentScroll({ items: liveItems });
   const [overlay, setOverlay] = useState<"model" | null>(null);
   const [lastUserMessage, setLastUserMessage] = useState("");
   const [doneStatus, setDoneStatus] = useState<{
@@ -472,6 +476,34 @@ export function App(props: AppProps) {
   const handleTaskNavigate = useCallback((index: number) => {
     setSelectedTaskIndex(index);
   }, []);
+
+  // ── Content area scroll (PageUp / PageDown) ────────────
+  useInput(
+    (_input, key) => {
+      if (key.pageUp) {
+        contentScroll.scrollUp(contentScroll.halfViewport);
+      } else if (key.pageDown) {
+        contentScroll.scrollDown(contentScroll.halfViewport);
+      }
+    },
+    { isActive: !taskBarFocused && overlay === null },
+  );
+
+  // ── Content area scroll (mouse / trackpad) ──────────────
+  const mouseScrollUp = useCallback(() => {
+    contentScroll.scrollUp(3);
+  }, [contentScroll]);
+  const mouseScrollDown = useCallback(() => {
+    contentScroll.scrollDown(3);
+  }, [contentScroll]);
+  // Only enable SGR mouse tracking when live area has scrollable content.
+  // Otherwise, let the terminal handle scrollback natively (iTerm2/VS Code).
+  const hasScrollableContent = liveItems.length > (contentScroll.halfViewport * 2);
+  useMouseScroll({
+    onScrollUp: mouseScrollUp,
+    onScrollDown: mouseScrollDown,
+    isActive: hasScrollableContent && !taskBarFocused && overlay === null,
+  });
 
   const agentLoop = useAgentLoop(
     messagesRef,
@@ -707,9 +739,10 @@ export function App(props: AppProps) {
         }
         return [];
       });
+      contentScroll.scrollToBottom();
     }
     wasRunningRef.current = agentLoop.isRunning;
-  }, [agentLoop.isRunning]);
+  }, [agentLoop.isRunning, contentScroll.scrollToBottom]);
 
   // Sync terminal title with agent loop state
   useEffect(() => {
@@ -971,96 +1004,104 @@ export function App(props: AppProps) {
     [customCommands],
   );
 
-  const renderItem = (item: CompletedItem) => {
-    switch (item.kind) {
-      case "banner":
-        return (
-          <Banner
-            key={item.id}
-            version={props.version}
-            model={props.model}
-            provider={props.provider}
-            cwd={props.cwd}
-          />
-        );
-      case "user":
-        return <UserMessage key={item.id} text={item.text} imageCount={item.imageCount} />;
-      case "assistant":
-        return (
-          <AssistantMessage
-            key={item.id}
-            text={item.text}
-            thinking={item.thinking}
-            thinkingMs={item.thinkingMs}
-            showThinking={props.showThinking}
-          />
-        );
-      case "tool_start":
-        return <ToolExecution key={item.id} status="running" name={item.name} args={item.args} />;
-      case "tool_done":
-        return (
-          <ToolExecution
-            key={item.id}
-            status="done"
-            name={item.name}
-            args={item.args}
-            result={item.result}
-            isError={item.isError}
-          />
-        );
-      case "server_tool_start":
-        return (
-          <ServerToolExecution key={item.id} status="running" name={item.name} input={item.input} />
-        );
-      case "server_tool_done":
-        return (
-          <ServerToolExecution
-            key={item.id}
-            status="done"
-            name={item.name}
-            input={item.input}
-            resultType={item.resultType}
-            data={item.data}
-          />
-        );
-      case "error":
-        return (
-          <Box key={item.id} marginTop={1}>
-            <Text color={theme.error}>{"✗ "}</Text>
-            <Text color={theme.error}>{item.message}</Text>
-          </Box>
-        );
-      case "info":
-        return (
-          <Box key={item.id} marginTop={1}>
-            <Text color={theme.textDim}>{item.text}</Text>
-          </Box>
-        );
-      case "compacting":
-        return <CompactionSpinner key={item.id} />;
-      case "compacted":
-        return (
-          <CompactionDone
-            key={item.id}
-            originalCount={item.originalCount}
-            newCount={item.newCount}
-            tokensBefore={item.tokensBefore}
-            tokensAfter={item.tokensAfter}
-          />
-        );
-      case "duration":
-        return (
-          <Box key={item.id} marginTop={1}>
-            <Text color={theme.textDim}>
-              {"✻ "}
-              {item.verb} {formatDuration(item.durationMs)}
-            </Text>
-          </Box>
-        );
-      case "subagent_group":
-        return <SubAgentPanel key={item.id} agents={item.agents} aborted={item.aborted} />;
-    }
-  };
+  const renderItem = useCallback(
+    (item: CompletedItem) => {
+      switch (item.kind) {
+        case "banner":
+          return (
+            <Banner
+              key={item.id}
+              version={props.version}
+              model={props.model}
+              provider={props.provider}
+              cwd={props.cwd}
+            />
+          );
+        case "user":
+          return <UserMessage key={item.id} text={item.text} imageCount={item.imageCount} />;
+        case "assistant":
+          return (
+            <AssistantMessage
+              key={item.id}
+              text={item.text}
+              thinking={item.thinking}
+              thinkingMs={item.thinkingMs}
+              showThinking={props.showThinking}
+            />
+          );
+        case "tool_start":
+          return <ToolExecution key={item.id} status="running" name={item.name} args={item.args} />;
+        case "tool_done":
+          return (
+            <ToolExecution
+              key={item.id}
+              status="done"
+              name={item.name}
+              args={item.args}
+              result={item.result}
+              isError={item.isError}
+            />
+          );
+        case "server_tool_start":
+          return (
+            <ServerToolExecution
+              key={item.id}
+              status="running"
+              name={item.name}
+              input={item.input}
+            />
+          );
+        case "server_tool_done":
+          return (
+            <ServerToolExecution
+              key={item.id}
+              status="done"
+              name={item.name}
+              input={item.input}
+              resultType={item.resultType}
+              data={item.data}
+            />
+          );
+        case "error":
+          return (
+            <Box key={item.id} marginTop={1}>
+              <Text color={theme.error}>{"✗ "}</Text>
+              <Text color={theme.error}>{item.message}</Text>
+            </Box>
+          );
+        case "info":
+          return (
+            <Box key={item.id} marginTop={1}>
+              <Text color={theme.textDim}>{item.text}</Text>
+            </Box>
+          );
+        case "compacting":
+          return <CompactionSpinner key={item.id} />;
+        case "compacted":
+          return (
+            <CompactionDone
+              key={item.id}
+              originalCount={item.originalCount}
+              newCount={item.newCount}
+              tokensBefore={item.tokensBefore}
+              tokensAfter={item.tokensAfter}
+            />
+          );
+        case "duration":
+          return (
+            <Box key={item.id} marginTop={1}>
+              <Text color={theme.textDim}>
+                {"✻ "}
+                {item.verb} {formatDuration(item.durationMs)}
+              </Text>
+            </Box>
+          );
+        case "subagent_group":
+          return <SubAgentPanel key={item.id} agents={item.agents} aborted={item.aborted} />;
+      }
+    },
+    [props.version, props.model, props.provider, props.cwd, props.showThinking, theme],
+  );
 
   return (
     <Box flexDirection="column">
@@ -1087,8 +1128,14 @@ export function App(props: AppProps) {
           when text wraps at the exact terminal edge */}
 
       <Box flexDirection="column" flexGrow={1} paddingRight={1}>
-        {/* Live items — current/last turn, stays visible */}
-        {liveItems.map((item) => renderItem(item))}
+        {/* Live items — current/last turn, viewport-sliced with scroll */}
+        {contentScroll.itemsAbove > 0 && (
+          <ScrollIndicator direction="up" count={contentScroll.itemsAbove} />
+        )}
+        {contentScroll.visibleItems.map((item) => renderItem(item))}
+        {contentScroll.itemsBelow > 0 && (
+          <ScrollIndicator direction="down" count={contentScroll.itemsBelow} />
+        )}
 
         {/* Streaming area — thinking text + response text */}
         <StreamingArea
@@ -1103,6 +1150,7 @@ export function App(props: AppProps) {
       {/* Pinned status line — activity indicator while running, duration summary when done */}
       {agentLoop.isRunning && agentLoop.activityPhase !== "idle" ? (
         <Box
+          flexShrink={0}
           marginTop={1}
           borderStyle={agentLoop.activityPhase === "thinking" ? "round" : undefined}
           borderColor={
@@ -1124,7 +1172,7 @@ export function App(props: AppProps) {
         </Box>
       ) : (
         doneStatus && (
-          <Box marginTop={1}>
+          <Box marginTop={1} flexShrink={0}>
             <Text color={doneFlash ? theme.success : theme.textDim}>
               {"✻ "}
               {doneStatus.verb} {formatDuration(doneStatus.durationMs)}
@@ -1134,45 +1182,51 @@ export function App(props: AppProps) {
       )}
 
       {/* Input + Footer/ModelSelector pinned at bottom */}
-      <InputArea
-        onSubmit={handleSubmit}
-        onAbort={handleAbort}
-        disabled={agentLoop.isRunning}
-        isActive={!taskBarFocused}
-        onDownAtEnd={handleFocusTaskBar}
-        onShiftTab={handleToggleThinking}
-        cwd={props.cwd}
-        commands={allCommands}
-      />
-      {overlay === "model" ? (
-        <ModelSelector
-          onSelect={handleModelSelect}
-          onCancel={() => setOverlay(null)}
-          loggedInProviders={props.loggedInProviders ?? [currentProvider]}
-          currentModel={currentModel}
-          currentProvider={currentProvider}
-        />
-      ) : (
-        <Footer
-          model={currentModel}
-          tokensIn={agentLoop.contextUsed}
+      <Box flexShrink={0}>
+        <InputArea
+          onSubmit={handleSubmit}
+          onAbort={handleAbort}
+          disabled={agentLoop.isRunning}
+          isActive={!taskBarFocused}
+          onDownAtEnd={handleFocusTaskBar}
+          onShiftTab={handleToggleThinking}
           cwd={props.cwd}
-          gitBranch={gitBranch}
-          thinkingEnabled={thinkingEnabled}
+          commands={allCommands}
         />
-      )}
+      </Box>
+      <Box flexShrink={0}>
+        {overlay === "model" ? (
+          <ModelSelector
+            onSelect={handleModelSelect}
+            onCancel={() => setOverlay(null)}
+            loggedInProviders={props.loggedInProviders ?? [currentProvider]}
+            currentModel={currentModel}
+            currentProvider={currentProvider}
+          />
+        ) : (
+          <Footer
+            model={currentModel}
+            tokensIn={agentLoop.contextUsed}
+            cwd={props.cwd}
+            gitBranch={gitBranch}
+            thinkingEnabled={thinkingEnabled}
+          />
+        )}
+      </Box>
       {bgTasks.length > 0 && (
-        <BackgroundTasksBar
-          tasks={bgTasks}
-          focused={taskBarFocused}
-          expanded={taskBarExpanded}
-          selectedIndex={selectedTaskIndex}
-          onExpand={handleTaskBarExpand}
-          onCollapse={handleTaskBarCollapse}
-          onKill={handleTaskKill}
-          onExit={handleTaskBarExit}
-          onNavigate={handleTaskNavigate}
-        />
+        <Box flexShrink={0}>
+          <BackgroundTasksBar
+            tasks={bgTasks}
+            focused={taskBarFocused}
+            expanded={taskBarExpanded}
+            selectedIndex={selectedTaskIndex}
+            onExpand={handleTaskBarExpand}
+            onCollapse={handleTaskBarCollapse}
+            onKill={handleTaskKill}
+            onExit={handleTaskBarExit}
+            onNavigate={handleTaskNavigate}
+          />
+        </Box>
       )}
     </Box>
   );

--- a/packages/gg-coding-agent/src/ui/components/ActivityIndicator.tsx
+++ b/packages/gg-coding-agent/src/ui/components/ActivityIndicator.tsx
@@ -3,7 +3,7 @@ import { Text, Box } from "ink";
 import { useTheme } from "../theme/theme.js";
 import type { ActivityPhase } from "../hooks/useAgentLoop.js";
 
-import { SPINNER_FRAMES, SPINNER_INTERVAL } from "../spinner-frames.js";
+import { SPINNER_FRAMES } from "../spinner-frames.js";
 
 // ── Color pulse cycle ─────────────────────────────────────
 
@@ -16,12 +16,9 @@ const PULSE_COLORS = [
   "#38bdf8", // sky
   "#60a5fa", // blue (back)
 ];
-const PULSE_INTERVAL = 400;
-
 // ── Ellipsis animation ────────────────────────────────────
 
 const ELLIPSIS_FRAMES = ["", ".", "..", "..."];
-const ELLIPSIS_INTERVAL = 500;
 
 // ── Phrase rotation ───────────────────────────────────────
 
@@ -220,7 +217,6 @@ function buildMetaSuffix(
 // ── Shimmer effect ────────────────────────────────────────
 
 const SHIMMER_WIDTH = 3;
-const SHIMMER_INTERVAL = 100;
 
 const ShimmerText: React.FC<{ text: string; color: string; shimmerPos: number }> = ({
   text,
@@ -260,66 +256,36 @@ export function ActivityIndicator({
 }: ActivityIndicatorProps) {
   const theme = useTheme();
 
-  // Spinner frame
-  const [spinnerFrame, setSpinnerFrame] = useState(0);
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setSpinnerFrame((f) => (f + 1) % SPINNER_FRAMES.length);
-    }, SPINNER_INTERVAL);
-    return () => clearInterval(timer);
-  }, []);
-
-  // Color pulse
-  const [colorFrame, setColorFrame] = useState(0);
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setColorFrame((f) => (f + 1) % PULSE_COLORS.length);
-    }, PULSE_INTERVAL);
-    return () => clearInterval(timer);
-  }, []);
-
-  // Ellipsis
-  const [ellipsisFrame, setEllipsisFrame] = useState(0);
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setEllipsisFrame((f) => (f + 1) % ELLIPSIS_FRAMES.length);
-    }, ELLIPSIS_INTERVAL);
-    return () => clearInterval(timer);
-  }, []);
-
-  // Shimmer position
-  const [shimmerPos, setShimmerPos] = useState(-SHIMMER_WIDTH);
-
   // Phrase rotation — pick phrases based on phase + user message, shuffle, rotate
   const phrases = useMemo(
     () => shuffleArray(selectPhrases(phase, userMessage)),
     [phase, userMessage],
   );
   const phraseInterval = phase === "waiting" ? WAITING_PHRASE_INTERVAL : OTHER_PHRASE_INTERVAL;
-  const [phraseIndex, setPhraseIndex] = useState(0);
+
+  // Single tick counter drives all animations
+  const [tick, setTick] = useState(0);
   useEffect(() => {
-    setPhraseIndex(0);
+    setTick(0);
     const timer = setInterval(() => {
-      setPhraseIndex((i) => (i + 1) % phrases.length);
-    }, phraseInterval);
+      setTick((t) => t + 1);
+    }, 80);
     return () => clearInterval(timer);
   }, [phrases, phraseInterval]);
 
+  const spinnerFrame = tick % SPINNER_FRAMES.length;
+  const colorFrame = Math.floor(tick / 5) % PULSE_COLORS.length;
+  const ellipsisFrame = Math.floor(tick / 6) % ELLIPSIS_FRAMES.length;
+  const phraseIndex = Math.floor(tick / (phraseInterval / 80)) % phrases.length;
+
   const spinnerColor = PULSE_COLORS[colorFrame];
-  const phrase = phrases[phraseIndex % phrases.length] ?? phrases[0];
+  const phrase = phrases[phraseIndex] ?? phrases[0];
   const ellipsis = ELLIPSIS_FRAMES[ellipsisFrame];
 
-  // Shimmer animation — wraps across phrase text length
-  useEffect(() => {
-    setShimmerPos(-SHIMMER_WIDTH);
-    const timer = setInterval(() => {
-      setShimmerPos((pos) => {
-        const max = phrase.length + SHIMMER_WIDTH;
-        return pos >= max ? -SHIMMER_WIDTH : pos + 1;
-      });
-    }, SHIMMER_INTERVAL);
-    return () => clearInterval(timer);
-  }, [phrase]);
+  // Shimmer position derived from tick (~100ms per step)
+  const shimmerStep = Math.floor((tick * 80) / 100);
+  const shimmerRange = phrase.length + SHIMMER_WIDTH * 2;
+  const shimmerPos = shimmerRange > 0 ? (shimmerStep % shimmerRange) - SHIMMER_WIDTH : 0;
 
   // Pad ellipsis to prevent text from shifting
   const paddedEllipsis = ellipsis + " ".repeat(3 - ellipsis.length);

--- a/packages/gg-coding-agent/src/ui/components/InputArea.tsx
+++ b/packages/gg-coding-agent/src/ui/components/InputArea.tsx
@@ -4,6 +4,7 @@ import { useTheme } from "../theme/theme.js";
 import type { ImageAttachment } from "../../utils/image.js";
 import { extractImagePaths, readImageFile, getClipboardImage } from "../../utils/image.js";
 import { SlashCommandMenu, filterCommands, type SlashCommandInfo } from "./SlashCommandMenu.js";
+import { log } from "../../core/logger.js";
 
 const MAX_VISIBLE_LINES = 5;
 const PROMPT = "❯ ";
@@ -158,6 +159,16 @@ export function InputArea({
 
   useInput(
     (input, key) => {
+      // DEBUG: log every useInput call to debug.log
+      const hex = [...input].map((c) => c.charCodeAt(0).toString(16).padStart(2, "0")).join(" ");
+      log("INFO", "useInput", `input=${JSON.stringify(input)} hex=[${hex}]`, {
+        ctrl: String(key.ctrl),
+        meta: String(key.meta),
+        shift: String(key.shift),
+        escape: String(key.escape),
+        return: String(key.return),
+      });
+
       if (disabled) {
         if ((key.ctrl && input === "c") || key.escape) {
           onAbort();
@@ -317,8 +328,12 @@ export function InputArea({
       }
 
       if (input) {
-        setValue((v) => v.slice(0, cursor) + input + v.slice(cursor));
-        setCursor((c) => c + input.length);
+        const cleaned = input.replace(/\[<\d+;\d+;\d+[Mm]/g, "");
+        log("INFO", "useInput:catchall", `raw=${JSON.stringify(input)} cleaned=${JSON.stringify(cleaned)}`);
+        if (cleaned) {
+          setValue((v) => v.slice(0, cursor) + cleaned + v.slice(cursor));
+          setCursor((c) => c + cleaned.length);
+        }
       }
     },
     { isActive },

--- a/packages/gg-coding-agent/src/ui/components/Markdown.tsx
+++ b/packages/gg-coding-agent/src/ui/components/Markdown.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { Text, Box, useStdout } from "ink";
 import { marked, type Token, type Tokens } from "marked";
 import { useTheme, type Theme } from "../theme/theme.js";
@@ -11,7 +11,7 @@ export function Markdown({ children }: { children: string }) {
   const theme = useTheme();
   const { stdout } = useStdout();
   const columns = stdout?.columns ?? 80;
-  const tokens = marked.lexer(children);
+  const tokens = useMemo(() => marked.lexer(children), [children]);
   return (
     <Box flexDirection="column" flexShrink={1}>
       {renderTokens(tokens, theme, columns)}

--- a/packages/gg-coding-agent/src/ui/components/ScrollIndicator.tsx
+++ b/packages/gg-coding-agent/src/ui/components/ScrollIndicator.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { Text } from "ink";
+import { useTheme } from "../theme/theme.js";
+
+interface ScrollIndicatorProps {
+  direction: "up" | "down";
+  count: number;
+}
+
+export function ScrollIndicator({ direction, count }: ScrollIndicatorProps) {
+  const theme = useTheme();
+  const arrow = direction === "up" ? "↑" : "↓";
+  return (
+    <Text color={theme.textDim}>
+      ── {arrow} {count} more ──
+    </Text>
+  );
+}

--- a/packages/gg-coding-agent/src/ui/components/SelectList.tsx
+++ b/packages/gg-coding-agent/src/ui/components/SelectList.tsx
@@ -2,6 +2,8 @@ import React, { useState, useMemo } from "react";
 import { Box, Text, useInput } from "ink";
 import { useTheme } from "../theme/theme.js";
 
+const MAX_VISIBLE_ITEMS = 10;
+
 interface SelectListItem {
   label: string;
   value: string;
@@ -28,6 +30,21 @@ export function SelectList({ items, onSelect, onCancel, initialIndex = 0 }: Sele
         item.label.toLowerCase().includes(lower) || item.value.toLowerCase().includes(lower),
     );
   }, [items, filter]);
+
+  // Viewport slicing — keep selectedIndex visible
+  const startIndex = useMemo(() => {
+    if (filtered.length <= MAX_VISIBLE_ITEMS) return 0;
+    const idealStart = Math.max(0, selectedIndex - MAX_VISIBLE_ITEMS + 1);
+    return Math.min(idealStart, filtered.length - MAX_VISIBLE_ITEMS);
+  }, [filtered.length, selectedIndex]);
+
+  const visibleItems = useMemo(
+    () => filtered.slice(startIndex, startIndex + MAX_VISIBLE_ITEMS),
+    [filtered, startIndex],
+  );
+
+  const itemsAbove = startIndex;
+  const itemsBelow = Math.max(0, filtered.length - startIndex - MAX_VISIBLE_ITEMS);
 
   useInput((input, key) => {
     if (key.escape) {
@@ -71,15 +88,20 @@ export function SelectList({ items, onSelect, onCancel, initialIndex = 0 }: Sele
           <Text color={theme.textDim}>Filter: {filter}</Text>
         </Box>
       )}
-      {filtered.map((item, index) => (
-        <Box key={item.value}>
-          <Text color={index === selectedIndex ? theme.primary : theme.text}>
-            {index === selectedIndex ? "❯ " : "  "}
-            {item.label}
-          </Text>
-          {item.description && <Text color={theme.textDim}> — {item.description}</Text>}
-        </Box>
-      ))}
+      {itemsAbove > 0 && <Text color={theme.textDim}> ↑ {itemsAbove} more</Text>}
+      {visibleItems.map((item, i) => {
+        const realIndex = startIndex + i;
+        return (
+          <Box key={item.value}>
+            <Text color={realIndex === selectedIndex ? theme.primary : theme.text}>
+              {realIndex === selectedIndex ? "❯ " : "  "}
+              {item.label}
+            </Text>
+            {item.description && <Text color={theme.textDim}> — {item.description}</Text>}
+          </Box>
+        );
+      })}
+      {itemsBelow > 0 && <Text color={theme.textDim}> ↓ {itemsBelow} more</Text>}
       {filtered.length === 0 && <Text color={theme.textDim}>No matches</Text>}
       <Box marginTop={1}>
         <Text color={theme.textDim}>↑↓ navigate · Enter select · Esc cancel</Text>

--- a/packages/gg-coding-agent/src/ui/hooks/useAgentLoop.ts
+++ b/packages/gg-coding-agent/src/ui/hooks/useAgentLoop.ts
@@ -158,16 +158,16 @@ export function useAgentLoop(
       // Aggressive catch-up prevents text from lagging behind the LLM.
       const buffered = pending.length;
       let charsPerTick: number;
-      if (buffered > 500) charsPerTick = 60;
-      else if (buffered > 200) charsPerTick = 30;
-      else if (buffered > 50) charsPerTick = 12;
-      else charsPerTick = 4;
+      if (buffered > 500) charsPerTick = 180;
+      else if (buffered > 200) charsPerTick = 90;
+      else if (buffered > 50) charsPerTick = 36;
+      else charsPerTick = 12;
 
       const reveal = pending.slice(0, charsPerTick);
       textPendingRef.current = pending.slice(charsPerTick);
       textVisibleRef.current += reveal;
       setStreamingText(textVisibleRef.current);
-    }, 10);
+    }, 33);
   }, []);
 
   const flushAllText = useCallback(() => {

--- a/packages/gg-coding-agent/src/ui/hooks/useContentScroll.ts
+++ b/packages/gg-coding-agent/src/ui/hooks/useContentScroll.ts
@@ -1,0 +1,106 @@
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { log } from "../../core/logger.js";
+
+const VIEWPORT_SIZE = 15;
+
+interface UseContentScrollOptions<T> {
+  items: T[];
+  viewportSize?: number;
+}
+
+interface UseContentScrollResult<T> {
+  visibleItems: T[];
+  itemsAbove: number;
+  itemsBelow: number;
+  scrollUp: (count?: number) => void;
+  scrollDown: (count?: number) => void;
+  scrollToBottom: () => void;
+  scrollToTop: () => void;
+  halfViewport: number;
+}
+
+export function useContentScroll<T>({
+  items,
+  viewportSize = VIEWPORT_SIZE,
+}: UseContentScrollOptions<T>): UseContentScrollResult<T> {
+  const [scrollOffset, setScrollOffset] = useState(0);
+  const isAutoScrollRef = useRef(true);
+  const prevLengthRef = useRef(items.length);
+
+  // When items change and auto-scroll is on, stay pinned to bottom
+  useEffect(() => {
+    if (isAutoScrollRef.current) {
+      setScrollOffset(0);
+    }
+    prevLengthRef.current = items.length;
+  }, [items.length]);
+
+  const maxOffset = Math.max(0, items.length - viewportSize);
+  const halfViewport = Math.floor(viewportSize / 2);
+
+  // Use ref so scroll callbacks always read the latest maxOffset
+  const maxOffsetRef = useRef(maxOffset);
+  maxOffsetRef.current = maxOffset;
+
+  const scrollUp = useCallback(
+    (count = 1) => {
+      const mo = maxOffsetRef.current;
+      log("INFO", "contentScroll", `scrollUp(${count}) maxOffset=${mo}`);
+      setScrollOffset((prev) => {
+        const next = Math.min(prev + count, mo);
+        if (next > 0) isAutoScrollRef.current = false;
+        return next;
+      });
+    },
+    [], // stable — reads maxOffset from ref
+  );
+
+  const scrollDown = useCallback((count = 1) => {
+    log("INFO", "contentScroll", `scrollDown(${count})`);
+    setScrollOffset((prev) => {
+      const next = Math.max(0, prev - count);
+      if (next === 0) isAutoScrollRef.current = true;
+      return next;
+    });
+  }, []);
+
+  const scrollToBottom = useCallback(() => {
+    setScrollOffset(0);
+    isAutoScrollRef.current = true;
+  }, []);
+
+  const scrollToTop = useCallback(() => {
+    const mo = maxOffsetRef.current;
+    setScrollOffset(mo);
+    if (mo > 0) isAutoScrollRef.current = false;
+  }, []);
+
+  const visibleItems = useMemo(() => {
+    if (items.length <= viewportSize) return items;
+    // scrollOffset is items from the bottom
+    const end = items.length - scrollOffset;
+    const start = Math.max(0, end - viewportSize);
+    return items.slice(start, end);
+  }, [items, scrollOffset, viewportSize]);
+
+  const itemsAbove = useMemo(() => {
+    if (items.length <= viewportSize) return 0;
+    const end = items.length - scrollOffset;
+    return Math.max(0, end - viewportSize);
+  }, [items.length, scrollOffset, viewportSize]);
+
+  const itemsBelow = useMemo(() => {
+    return scrollOffset;
+  }, [scrollOffset]);
+
+  return {
+    visibleItems,
+    itemsAbove,
+    itemsBelow,
+    scrollUp,
+    scrollDown,
+    scrollToBottom,
+    scrollToTop,
+    halfViewport,
+  };
+}

--- a/packages/gg-coding-agent/src/ui/hooks/useMouseScroll.ts
+++ b/packages/gg-coding-agent/src/ui/hooks/useMouseScroll.ts
@@ -1,0 +1,66 @@
+import { useEffect } from "react";
+import { log } from "../../core/logger.js";
+
+// SGR mouse protocol sequences
+const MOUSE_ENABLE = "\x1b[?1000h\x1b[?1006h";
+const MOUSE_DISABLE = "\x1b[?1000l\x1b[?1006l";
+
+// SGR mouse event: \x1b[<button;col;row(M|m)
+// eslint-disable-next-line no-control-regex
+const SGR_MOUSE_RE = /\x1b\[<(\d+);\d+;\d+[Mm]/g;
+
+const SCROLL_UP_BUTTON = 64;
+const SCROLL_DOWN_BUTTON = 65;
+
+interface UseMouseScrollOptions {
+  onScrollUp: () => void;
+  onScrollDown: () => void;
+  isActive?: boolean;
+}
+
+export function useMouseScroll({
+  onScrollUp,
+  onScrollDown,
+  isActive = true,
+}: UseMouseScrollOptions): void {
+  useEffect(() => {
+    if (!isActive) return;
+
+    process.stdout.write(MOUSE_ENABLE);
+
+    const handler = (data: Buffer) => {
+      const str = data.toString("utf8");
+      const hex = [...data].map((b) => b.toString(16).padStart(2, "0")).join(" ");
+      log("INFO", "mouseScroll:raw", `bytes=[${hex}] str=${JSON.stringify(str)}`);
+      let match: RegExpExecArray | null;
+      SGR_MOUSE_RE.lastIndex = 0;
+      while ((match = SGR_MOUSE_RE.exec(str)) !== null) {
+        const button = Number(match[1]);
+        if (button === SCROLL_UP_BUTTON) {
+          log("INFO", "mouseScroll", `scroll UP detected (button=${button})`);
+          onScrollUp();
+        } else if (button === SCROLL_DOWN_BUTTON) {
+          log("INFO", "mouseScroll", `scroll DOWN detected (button=${button})`);
+          onScrollDown();
+        } else {
+          log("INFO", "mouseScroll", `other mouse event (button=${button})`);
+        }
+      }
+    };
+
+    process.stdin.on("data", handler);
+
+    const exitHandler = () => {
+      process.stdout.write(MOUSE_DISABLE);
+    };
+    process.on("exit", exitHandler);
+
+    return () => {
+      process.stdout.write(MOUSE_DISABLE);
+      process.stdin.off("data", handler);
+      process.off("exit", exitHandler);
+    };
+  }, [isActive, onScrollUp, onScrollDown]);
+}
+
+export { MOUSE_DISABLE };

--- a/packages/gg-coding-agent/src/ui/render.ts
+++ b/packages/gg-coding-agent/src/ui/render.ts
@@ -6,6 +6,7 @@ import type { ProcessManager } from "../core/process-manager.js";
 import { App, type CompletedItem } from "./App.js";
 import { SplashScreen } from "./components/SplashScreen.js";
 import { ThemeContext, loadTheme } from "./theme/theme.js";
+import { MOUSE_DISABLE } from "./hooks/useMouseScroll.js";
 
 export interface RenderAppConfig {
   provider: Provider;
@@ -133,6 +134,6 @@ export async function renderApp(config: RenderAppConfig): Promise<void> {
 
   process.stdout.off("resize", onResize);
 
-  // Reset scroll region and clear the shimmer line on exit
-  process.stdout.write("\x1b[r\x1b[1;1H\x1b[2K");
+  // Reset scroll region, disable mouse tracking, and clear the shimmer line on exit
+  process.stdout.write(MOUSE_DISABLE + "\x1b[r\x1b[1;1H\x1b[2K");
 }


### PR DESCRIPTION
## Summary

Adds viewport-based scrolling to the interactive TUI.

### New files
- `useContentScroll` hook — manages viewport offset, scroll up/down/toBottom
- `useMouseScroll` hook — SGR mouse protocol for trackpad/wheel events
- `ScrollIndicator` component — visual scroll position indicator

### Changes
- **App.tsx** — integrates scroll viewport, PageUp/PageDown key bindings, mouse scroll handlers
- **ActivityIndicator, InputArea, Markdown, SelectList** — compatibility updates for scroll state
- **useAgentLoop, render.ts** — scroll state management wiring

### How it works
- PageUp/PageDown scrolls by half-viewport
- Mouse wheel/trackpad scrolls 3 lines at a time
- SGR mouse tracking only activates when content exceeds viewport (preserves native terminal scrollback)
- Auto-scrolls to bottom when agent completes a turn