### PR TITLE
feat(ui): add jump-to-top/bottom keybindings in Task Pane

### DIFF
--- a/packages/ggcoder/src/ui/components/TaskOverlay.tsx
+++ b/packages/ggcoder/src/ui/components/TaskOverlay.tsx
@@ -220,6 +220,16 @@ export function TaskOverlay({
       return;
     }
 
+    // Jump to top (g) / bottom (G)
+    if (input === "g") {
+      setSelectedIndex(0);
+      return;
+    }
+    if (input === "G") {
+      setSelectedIndex(tasks.length - 1);
+      return;
+    }
+
     if (key.upArrow || input === "k") {
       setSelectedIndex((i) => Math.max(0, i - 1));
       return;
@@ -373,7 +383,9 @@ export function TaskOverlay({
       <Box marginTop={1}>
         <Text color={theme.textDim}>
           <Text color={theme.primary}>↑↓</Text>
-          {" move · ("}
+          {" move · "}
+          <Text color={theme.primary}>g/G</Text>
+          {" jump · ("}
           <Text color={theme.primary}>a</Text>
           {")dd · ("}
           <Text color={theme.primary}>e</Text>


### PR DESCRIPTION
## Summary

- Adds `g` (top) and `G` (bottom) keybindings to the Task Pane for instant navigation
- Follows the existing vim-style convention (`j`/`k` for move) with the natural `g`/`G` extension
- Updates the hint bar to show the new keybindings

## Why

With long task lists (50+), reaching the bottom requires holding the arrow key or pressing `j` dozens of times. This is a one-file, 13-line change.

## Files changed

| File | Change |
|------|--------|
| `ui/components/TaskOverlay.tsx` | Add `g`/`G` handlers before existing `j`/`k`, update hint bar |

## Test plan

- [ ] `g` jumps to first task
- [ ] `G` (Shift+G) jumps to last task
- [ ] Regular `j`/`k`/`↑`/`↓` movement still works
- [ ] Hint bar shows `g/G jump`
- [ ] No interference with add/edit input modes (handlers only fire in normal mode)

🤖 Generated with [GG Coder](https://github.com/KenKaiii/gg-framework)