### PR TITLE
fix(ggcoder): don't abort in-flight agent run when an overlay is opened or closed

### DIFF
--- a/packages/ggcoder/src/ui/App.tsx
+++ b/packages/ggcoder/src/ui/App.tsx
@@ -2724,7 +2724,12 @@ export function App(props: AppProps) {
           cwd={props.cwd}
           agentRunning={agentLoop.isRunning}
           onClose={() => {
-            if (props.resetUI && props.sessionStore) {
+            // Skip the unmount/remount when the agent is mid-run — the
+            // unmount fires useAgentLoop's cleanup which aborts the
+            // stream. Soft path (ANSI clear + Static recreate +
+            // setOverlay) preserves the live agent. Cursor-math drift
+            // recovers on the next idle close.
+            if (props.resetUI && props.sessionStore && !agentLoop.isRunning) {
               props.sessionStore.overlay = null;
               props.resetUI();
             } else {
@@ -2753,7 +2758,9 @@ export function App(props: AppProps) {
           version={props.version}
           agentRunning={agentLoop.isRunning}
           onClose={() => {
-            if (props.resetUI && props.sessionStore) {
+            // See TaskOverlay onClose — soft close while a run is
+            // in-flight so the unmount doesn't abort the stream.
+            if (props.resetUI && props.sessionStore && !agentLoop.isRunning) {
               props.sessionStore.overlay = null;
               props.resetUI();
             } else {
@@ -2778,7 +2785,9 @@ export function App(props: AppProps) {
         <SkillsOverlay
           cwd={props.cwd}
           onClose={() => {
-            if (props.resetUI && props.sessionStore) {
+            // See TaskOverlay onClose — soft close while a run is
+            // in-flight so the unmount doesn't abort the stream.
+            if (props.resetUI && props.sessionStore && !agentLoop.isRunning) {
               props.sessionStore.overlay = null;
               props.resetUI();
             } else {
@@ -2792,7 +2801,9 @@ export function App(props: AppProps) {
         <EyesOverlay
           cwd={props.cwd}
           onClose={() => {
-            if (props.resetUI && props.sessionStore) {
+            // See TaskOverlay onClose — soft close while a run is
+            // in-flight so the unmount doesn't abort the stream.
+            if (props.resetUI && props.sessionStore && !agentLoop.isRunning) {
               props.sessionStore.overlay = null;
               props.resetUI();
             } else {
@@ -2814,7 +2825,9 @@ export function App(props: AppProps) {
           autoExpandNewest={planAutoExpand}
           onClose={() => {
             planOverlayPendingRef.current = false;
-            if (props.resetUI && props.sessionStore) {
+            // See TaskOverlay onClose — soft close while a run is
+            // in-flight so the unmount doesn't abort the stream.
+            if (props.resetUI && props.sessionStore && !agentLoop.isRunning) {
               props.sessionStore.overlay = null;
               props.sessionStore.planAutoExpand = false;
               props.resetUI();
@@ -3026,7 +3039,11 @@ export function App(props: AppProps) {
             onDownAtEnd={handleFocusTaskBar}
             onShiftTab={handleToggleThinking}
             onToggleTasks={() => {
-              if (props.resetUI && props.sessionStore) {
+              // Soft path while the agent is running — see TaskOverlay
+              // onClose. resetUI()'s unmount aborts the in-flight stream;
+              // we'd rather keep the run alive and accept a small cursor
+              // drift that recovers on the next idle close.
+              if (props.resetUI && props.sessionStore && !agentLoop.isRunning) {
                 props.sessionStore.overlay = "tasks";
                 props.resetUI();
               } else {
@@ -3035,7 +3052,7 @@ export function App(props: AppProps) {
               }
             }}
             onToggleSkills={() => {
-              if (props.resetUI && props.sessionStore) {
+              if (props.resetUI && props.sessionStore && !agentLoop.isRunning) {
                 props.sessionStore.overlay = "skills";
                 props.resetUI();
               } else {
@@ -3044,7 +3061,7 @@ export function App(props: AppProps) {
               }
             }}
             onTogglePixel={() => {
-              if (props.resetUI && props.sessionStore) {
+              if (props.resetUI && props.sessionStore && !agentLoop.isRunning) {
                 props.sessionStore.overlay = "pixel";
                 props.resetUI();
               } else {


### PR DESCRIPTION
### Symptom

While the agent is mid-stream (streaming a response, running tool calls), pressing any of:

- `Ctrl+T` to **open** Tasks
- `Ctrl+S` to **open** Skills
- `Ctrl+E` to **open** Pixel
- `Esc` to **close** Tasks / Pixel / Skills / Eyes / Plan back to chat

…silently aborts the run. No error, no abort message, no continuation prompt. The user has to re-issue the message manually. The overlay covers the chat viewport so the dead state isn't visible until the user closes back, which is why it usually surfaces on Esc rather than on the open keystroke (the abort actually happens on the open).

### Reproduction

1. Send a prompt that takes a few seconds (research-y, multi-tool).
2. While streaming, press `Ctrl+T`.
3. Press `Esc` to come back to chat.
4. Agent has stopped — no spinner, no streaming text, no tool activity.

### Root cause

The overlay open/close handlers in `src/ui/App.tsx` call `props.resetUI()`, which tears down the React tree and renders a fresh Ink instance (`src/ui/render.ts:245-271` — the documented escape from cumulative live-area cursor drift, same fix `/clear` and resize use).

The full unmount fires every component's cleanup. `useAgentLoop` registers one at `src/ui/hooks/useAgentLoop.ts:724-733`:

```ts
useEffect(() => {
  return () => {
    abortRef.current?.abort();
    ...
  };
}, []);
```

`abortRef.current?.abort()` kills the in-flight stream. From the agent loop's perspective the user aborted; the new App boots with no notion that a run was in progress, so it doesn't resume.

Eight call sites that hit this path (line numbers vs `main` @ `2e71532`):

| # | Handler | App.tsx |
|---|---|---|
| 1 | `onToggleTasks` | 3028 |
| 2 | `onToggleSkills` | 3037 |
| 3 | `onTogglePixel` | 3046 |
| 4 | `TaskOverlay` `onClose` | 2726 |
| 5 | `PixelOverlay` `onClose` | 2755 |
| 6 | `SkillsOverlay` `onClose` | 2780 |
| 7 | `EyesOverlay` `onClose` | 2794 |
| 8 | `PlanOverlay` `onClose` | 2815 |

All eight unconditionally call `resetUI()` whenever `props.resetUI && props.sessionStore` are wired (always, in production — the `else` branches are documented as test fallbacks).

### Fix

The unmount/remount is load-bearing for cursor-math reasons, so it can't simply be removed — but it doesn't need to fire when the agent is mid-run.

Each of the eight call sites already has an `else` branch doing a soft close (ANSI clear + Static recreate via `staticKey` bump + `setOverlay`), originally written as a test fallback. Adding `&& !agentLoop.isRunning` to the eight guards routes mid-run open/close through the soft path; the `resetUI()` path runs as before when the agent is idle. Cursor-math drift recovers naturally on the next idle close after the run ends.

Plan-accept and plan-reject (`App.tsx:2828`, `:2912`) are intentionally left on the `resetUI` path — those are user-initiated transitions that legitimately want a fresh tree, and only fire from the plan overlay where there's no concurrent agent run.

### Behaviour change

None for non-running paths — the `resetUI()` call shape is identical when the agent is idle. The only observable difference is that overlays opened/closed during a run no longer kill the stream, and may have a one-frame cursor-position skew until the next idle close (which is the same skew that previously triggered the unmount/remount design).

### Verified on

- WSL2 (Linux 6.6.87.2-microsoft-standard-WSL2) on Windows 11
- Windows Terminal
- `@kenkaiiii/ggcoder@4.3.156` (rebuilt locally from this branch)
- `pnpm check`, `pnpm lint`, `pnpm test` (344/344) all pass

Reproduced by **one other user** on a similar WSL2 setup, so N=2 minimum but I cannot claim universality. The code path fires unconditionally on every install, so the *fix* is plausibly platform-independent — but I haven't verified that the *symptom* manifests on native Linux, macOS, or non-WSL Windows. Worth a sanity check on your end before merging.
