### PR TITLE
fix(ggcoder): persist run-all flags through per-task remount so the chain doesn't die after task #1

### DIFF
--- a/packages/ggcoder/src/ui/App.tsx
+++ b/packages/ggcoder/src/ui/App.tsx
@@ -588,6 +588,8 @@ export interface AppProps {
     sessionTitleGenerated: boolean;
     overlay?: "model" | "tasks" | "skills" | "plan" | "theme" | "eyes" | "pixel" | null;
     planAutoExpand?: boolean;
+    runAllTasks?: boolean;
+    runAllPixel?: boolean;
     pendingAction?: { prompt: string; infoText?: string };
   };
 }
@@ -651,10 +653,13 @@ export function App(props: AppProps) {
   const [updatePending, setUpdatePending] = useState<boolean>(
     () => getPendingUpdate(props.version) !== null,
   );
-  const [runAllTasks, setRunAllTasks] = useState(false);
-  const runAllTasksRef = useRef(false);
+  // runAllTasks must survive the unmount/remount that startTask triggers
+  // for each task (wipeSession: true gives every task a fresh session).
+  // Seed from sessionStore so the chain keeps going after task #1.
+  const [runAllTasks, setRunAllTasks] = useState(props.sessionStore?.runAllTasks ?? false);
+  const runAllTasksRef = useRef(props.sessionStore?.runAllTasks ?? false);
   const startTaskRef = useRef<(title: string, prompt: string, taskId: string) => void>(() => {});
-  const runAllPixelRef = useRef(false);
+  const runAllPixelRef = useRef(props.sessionStore?.runAllPixel ?? false);
   const currentPixelFixRef = useRef<PreparedPixelFix | null>(null);
   const startPixelFixRef = useRef<(errorId: string) => void>(() => {});
   const cwdRef = useRef(props.cwd);
@@ -2612,7 +2617,8 @@ export function App(props: AppProps) {
   startTaskRef.current = startTask;
   useEffect(() => {
     runAllTasksRef.current = runAllTasks;
-  }, [runAllTasks]);
+    if (props.sessionStore) props.sessionStore.runAllTasks = runAllTasks;
+  }, [runAllTasks, props.sessionStore]);
 
   const startPixelFix = useCallback(
     (errorId: string) => {
@@ -2692,10 +2698,12 @@ export function App(props: AppProps) {
   );
   startPixelFixRef.current = startPixelFix;
 
-  const [runAllPixel, setRunAllPixel] = useState(false);
+  // See runAllTasks above — same persistence story for pixel run-all.
+  const [runAllPixel, setRunAllPixel] = useState(props.sessionStore?.runAllPixel ?? false);
   useEffect(() => {
     runAllPixelRef.current = runAllPixel;
-  }, [runAllPixel]);
+    if (props.sessionStore) props.sessionStore.runAllPixel = runAllPixel;
+  }, [runAllPixel, props.sessionStore]);
 
   const isTaskView = overlay === "tasks";
   const isSkillsView = overlay === "skills";

--- a/packages/ggcoder/src/ui/render.ts
+++ b/packages/ggcoder/src/ui/render.ts
@@ -91,6 +91,16 @@ export interface SessionStore {
   /** Plan overlay auto-expand-newest flag (only meaningful when overlay==='plan'). */
   planAutoExpand?: boolean;
   /**
+   * "Run all" chained-execution flags. Persist across the unmount/remount
+   * triggered by `startTask` / `startPixelFix` (each task gets a fresh
+   * session via `wipeSession: true`). Without persistence, the new App
+   * boots with `useState(false)` and the chain dies after task #1.
+   * Deliberately NOT cleared by `wipeSession` — the whole point is for
+   * them to span per-task resets.
+   */
+  runAllTasks?: boolean;
+  runAllPixel?: boolean;
+  /**
    * Action to run on the next mount (consumed once). Used by paths that
    * remount AND immediately drive the agent — plan accept / reject,
    * startTask, etc. The new App reads this on mount, fires the agent,
@@ -181,6 +191,8 @@ export async function renderApp(config: RenderAppConfig): Promise<void> {
     sessionTitleGenerated: false,
     overlay: config.initialOverlay ?? null,
     planAutoExpand: false,
+    runAllTasks: false,
+    runAllPixel: false,
     pendingAction: undefined,
   };
 


### PR DESCRIPTION
### Symptom

User adds several pending tasks, opens the Tasks overlay, presses `r` to "run all". Task #1 starts, runs to completion, and the run-all sequence halts. Tasks #2…#N remain pending. No error, no message, no auto-advance.

Pressing `Enter` to manually start each task one at a time still works — only the chained `r` path is broken. The PixelOverlay "fix all" path has the same shape and the same bug.

### Reproduction

1. Add at least three tasks via the Tasks overlay (`a` to add).
2. Press `r` to start "run all".
3. Task #1 runs to completion (agent finishes, calls `tasks({action:"done", id:…})` as instructed).
4. Expected: task #2 auto-starts. Actual: nothing happens. Tasks #2 and #3 remain pending.

### Root cause

`runAllTasks` is plain React state in `src/ui/App.tsx:654`:

```ts
const [runAllTasks, setRunAllTasks] = useState(false);
const runAllTasksRef = useRef(false);
```

Set `true` when the user presses `r` (`TaskOverlay` `onRunAllTasks` handler at `App.tsx:2741`). The auto-advance check in `onDone` reads it via the ref at `App.tsx:1577`:

```ts
if (runAllTasksRef.current) {
  setTimeout(() => {
    const next = getNextPendingTask(cwdRef.current);
    if (next) {
      markTaskInProgress(cwdRef.current, next.id);
      startTaskRef.current(next.title, next.prompt, next.id);
    } else {
      setRunAllTasks(false);
    }
  }, 500);
}
```

The problem: `startTask` itself (`App.tsx:2532`) calls `resetUI({ wipeSession: true, … })` to give every task a fresh session. That is a full unmount/remount per task. The new App boots with `useState(false)` for `runAllTasks` — there is no carry-through.

By the time `onDone` fires for task #1, it runs inside the **new** App instance, where `runAllTasksRef.current === false` (the new App never saw `setRunAllTasks(true)`). The auto-advance check fails silently and the chain dies.

Same bug for the Pixel run-all path (`PixelOverlay` `onFixAll` at `App.tsx:2769`) — `runAllPixel` is local React state at `App.tsx:2695`, not carried across the unmount in `startPixelFix`.

### Fix

Persist both flags through the same `SessionStore` mechanism that already carries `messages`, `history`, `planSteps`, `overlay`, etc. across the unmount/remount.

- **`render.ts`** — add `runAllTasks?: boolean` and `runAllPixel?: boolean` fields to `SessionStore`. Initialised to `false` on first boot. Deliberately **not** cleared by `wipeSession: true` in `resetUI` — the whole point is for them to span per-task resets.
- **`App.tsx`** — `AppProps`' inline `sessionStore` shape extended with the same two fields. Both `useState` calls now seed from the store (`props.sessionStore?.runAllTasks ?? false`); the existing `useEffect` mirrors now also write back to the store on every change, matching the pattern already used for `messages` / `history` / `planSteps` / `overlay`.
- The two refs are seeded from the store too, so closures captured before the first `useEffect` commit also see the correct value.

### Behaviour change

None for non-run-all paths — the flags default to `false` and only become `true` when the user explicitly presses `r` / "fix all".

### Verified on

- WSL2 (Linux 6.6.87.2-microsoft-standard-WSL2) on Windows 11
- Windows Terminal
- `@kenkaiiii/ggcoder@4.3.156` (rebuilt locally from this branch)
- `pnpm check`, `pnpm lint`, `pnpm test` (344/344) all pass
- Smoke-tested with 3-task run-all: chain now completes end-to-end

Reproduced by **one other user** on a similar WSL2 setup. The state loss on remount is platform-independent in principle (React lifecycle, not terminal-specific), so I'd expect this to manifest on every platform — but I haven't confirmed it outside WSL. Sanity check welcome.
