### PR TITLE
Fix gg-boss Telegram polling and gg-pixel fix flow

### DIFF
--- a/packages/gg-boss/src/telegram.ts
+++ b/packages/gg-boss/src/telegram.ts
@@ -108,16 +108,24 @@ export class TelegramBot {
       throw new Error(`Invalid bot token: ${JSON.stringify(me)}`);
     }
 
+    let attempt = 0;
     while (this.running) {
       try {
         const updates = await this.getUpdates();
         for (const update of updates) {
           await this.handleUpdate(update);
+          // Advance offset only after successfully handling this update.
+          // If handleUpdate throws, do NOT advance — so it will be retried.
+          this.offset = update.update_id + 1;
         }
+        attempt = 0;
       } catch (err) {
         if (!this.running) break;
         console.error(`[telegram] Poll error: ${err instanceof Error ? err.message : err}`);
-        await sleep(3000);
+        const delay = Math.min(3000 * 2 ** attempt, 30_000);
+        const jitter = delay * (0.8 + Math.random() * 0.4);
+        await sleep(jitter);
+        attempt++;
       }
     }
   }
@@ -146,7 +154,7 @@ export class TelegramBot {
       await this.apiCall("sendMessage", {
         chat_id: chatId,
         text: chunks[i],
-        parse_mode: "Markdown",
+        parse_mode: "HTML",
         ...(replyMarkup ? { reply_markup: replyMarkup } : {}),
       });
     }
@@ -182,19 +190,18 @@ export class TelegramBot {
   // ── Private ───────────────────────────────────────────
 
   private async getUpdates(): Promise<TelegramUpdate[]> {
-    const result = await this.apiCall("getUpdates", {
-      offset: this.offset,
-      timeout: 30,
-      allowed_updates: ["message", "callback_query", "my_chat_member"],
-    });
+    const result = await this.apiCall(
+      "getUpdates",
+      {
+        offset: this.offset,
+        timeout: 30,
+        allowed_updates: ["message", "callback_query", "my_chat_member"],
+      },
+      { signal: AbortSignal.timeout(35_000) },
+    );
 
     if (!result.ok || !Array.isArray(result.result)) return [];
-
-    const updates = result.result as TelegramUpdate[];
-    if (updates.length > 0) {
-      this.offset = updates[updates.length - 1]!.update_id + 1;
-    }
-    return updates;
+    return result.result as TelegramUpdate[];
   }
 
   private async handleUpdate(update: TelegramUpdate): Promise<void> {
@@ -251,6 +258,7 @@ export class TelegramBot {
   private async apiCall(
     method: string,
     body?: Record<string, unknown>,
+    fetchInit?: RequestInit,
   ): Promise<{ ok: boolean; result?: unknown }> {
     const url = `${TELEGRAM_API}/bot${this.token}/${method}`;
 
@@ -258,6 +266,7 @@ export class TelegramBot {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: body ? JSON.stringify(body) : undefined,
+      ...fetchInit,
     });
 
     if (!response.ok) {
@@ -271,10 +280,10 @@ export class TelegramBot {
 // ── Markdown Conversion ──────────────────────────────────
 
 /**
- * Convert GitHub-flavored markdown to Telegram-compatible Markdown.
+ * Convert GitHub-flavored markdown to Telegram-compatible HTML.
  *
- * Telegram supports: *bold*, _italic_, `code`, ```pre```, [link](url)
- * Does NOT support: headings, horizontal rules, tables, HTML tags, images
+ * Telegram supports HTML: <b>, <i>, <code>, <pre>, <a href>
+ * Does NOT support: headings, horizontal rules, tables, images
  */
 function toTelegramMarkdown(text: string): string {
   const lines = text.split("\n");
@@ -298,7 +307,7 @@ function toTelegramMarkdown(text: string): string {
     // Headings → bold text
     const headingMatch = transformed.match(/^(#{1,6})\s+(.+)$/);
     if (headingMatch) {
-      transformed = `*${headingMatch[2]}*`;
+      transformed = `<b>${headingMatch[2]}</b>`;
       result.push(transformed);
       continue;
     }
@@ -309,8 +318,17 @@ function toTelegramMarkdown(text: string): string {
       continue;
     }
 
-    // **bold** → *bold*
-    transformed = transformed.replace(/\*\*(.+?)\*\*/g, "*$1*");
+    // **bold** → <b>…</b>
+    transformed = transformed.replace(/\*\*(.+?)\*\*/g, "<b>$1</b>");
+
+    // _italic_ → <i>…</i>
+    transformed = transformed.replace(/(?<!\*)_(.+?)_(?!\*)/g, "<i>$1</i>");
+
+    // `code` → <code>…</code>
+    transformed = transformed.replace(/`([^`]+)`/g, "<code>$1</code>");
+
+    // [text](url) GFM links → just the link text (no raw link syntax)
+    transformed = transformed.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
 
     result.push(transformed);
   }

--- a/packages/ggcoder/src/core/pixel-fix.ts
+++ b/packages/ggcoder/src/core/pixel-fix.ts
@@ -74,7 +74,13 @@ export async function fixError(errorId: string, opts: FixOptions = {}): Promise<
   const owner = await resolveErrorOwner(fetchFn, ingestUrl, errorId, home);
   const { error, project, secret } = owner;
 
-  const branch = `fix/pixel-${error.id}`;
+  const baseBranch = `fix/pixel-${error.id}`;
+  const branch = await buildRetryBranch(
+    baseBranch,
+    error.branch,
+    opts.spawnFn ?? spawn,
+    project.path,
+  );
   await patchError(fetchFn, ingestUrl, error.id, { status: "in_progress", branch }, secret);
 
   const exitCode = await runAgent({
@@ -137,6 +143,7 @@ export async function runQueue(opts: QueueOptions = {}): Promise<{
     try {
       const res = await fetchFn(`${ingestUrl}/api/projects/${projectId}/errors?status=open`, {
         headers: { authorization: `Bearer ${project.secret}` },
+        signal: AbortSignal.timeout(30_000),
       });
       if (!res.ok) continue;
       const body = (await res.json()) as { errors: Array<{ id: string }> };
@@ -193,7 +200,7 @@ export interface PreparedPixelFix {
   prompt: string;
 }
 
-export interface PrepareOptions {
+export interface PrepareOptions extends FixOptions {
   ingestUrl?: string;
   homeDir?: string;
   fetchFn?: typeof fetch;
@@ -207,20 +214,40 @@ export async function preparePixelFix(
   const fetchFn = opts.fetchFn ?? fetch;
   const home = opts.homeDir ?? homedir();
 
-  const owner = await resolveErrorOwner(fetchFn, ingestUrl, errorId, home);
-  const { error, project, secret } = owner;
-  const branch = `fix/pixel-${error.id}`;
+  let owner: Awaited<ReturnType<typeof resolveErrorOwner>> | undefined;
+  try {
+    owner = await resolveErrorOwner(fetchFn, ingestUrl, errorId, home);
+    const { error, project, secret } = owner;
 
-  await patchError(fetchFn, ingestUrl, error.id, { status: "in_progress", branch }, secret);
+    const baseBranch = `fix/pixel-${error.id}`;
+    const branch = await buildRetryBranch(
+      baseBranch,
+      error.branch,
+      opts.spawnFn ?? spawn,
+      project.path,
+    );
 
-  return {
-    errorId: error.id,
-    projectId: error.project_id,
-    projectName: project.name,
-    projectPath: project.path,
-    branch,
-    prompt: buildAgentPrompt(error, branch, project.path),
-  };
+    await patchError(fetchFn, ingestUrl, error.id, { status: "in_progress", branch }, secret);
+
+    return {
+      errorId: error.id,
+      projectId: error.project_id,
+      projectName: project.name,
+      projectPath: project.path,
+      branch,
+      prompt: buildAgentPrompt(error, branch, project.path),
+    };
+  } catch (err) {
+    // Rollback: if we resolved the owner and set in_progress, revert to open.
+    if (owner) {
+      try {
+        await patchError(fetchFn, ingestUrl, owner.error.id, { status: "open" }, owner.secret);
+      } catch {
+        // rollback failed — log and continue; original error is more relevant
+      }
+    }
+    throw err;
+  }
 }
 
 export interface FinalizeOptions extends PrepareOptions {
@@ -352,12 +379,21 @@ async function resolveErrorOwner(
   for (const [, project] of ownersWithSecret) {
     const res = await fetchFn(`${ingestUrl}/api/errors/${errorId}`, {
       headers: { authorization: `Bearer ${project.secret}` },
+      signal: AbortSignal.timeout(30_000),
     });
+    if (res.status === 401) {
+      console.warn(
+        chalk.hex("#fbbf24")(
+          `⚠ 401 for project ${project.name} — secret may need refresh. Run \`ggcoder pixel install\` to refresh.`,
+        ),
+      );
+      continue;
+    }
     if (res.ok) {
       const error = (await res.json()) as ErrorRow;
       return { error, project, secret: project.secret! };
     }
-    // 401/403/404 → not this project; keep scanning.
+    // 403/404 → not this project; keep scanning.
   }
   throw new Error(
     `Error ${errorId} was not found in any registered project. Ensure the project is installed (\`ggcoder pixel install\`).`,
@@ -400,6 +436,7 @@ async function patchError(
       authorization: `Bearer ${secret}`,
     },
     body: JSON.stringify(body),
+    signal: AbortSignal.timeout(30_000),
   });
   if (!res.ok) throw new Error(`PATCH /api/errors/${errorId} failed: ${res.status}`);
 }
@@ -428,8 +465,37 @@ async function runAgent(opts: AgentRunOptions): Promise<number> {
       cwd: opts.cwd,
       stdio: opts.inheritStdio ? "inherit" : ["ignore", "pipe", "pipe"],
     });
-    child.on("error", reject);
-    child.on("exit", (code) => resolve(code ?? 1));
+
+    const cleanup = () => {
+      try {
+        child.kill();
+      } catch {
+        /* already dead */
+      }
+    };
+
+    const onSignal = (signal: string) => {
+      cleanup();
+      reject(new Error(`Received ${signal} — agent killed`));
+    };
+
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
+    const onExit = (code: number | null) => {
+      process.removeListener("SIGTERM", sigtermHandler);
+      process.removeListener("SIGINT", sigintHandler);
+      resolve(code ?? 1);
+    };
+
+    const sigtermHandler = () => onSignal("SIGTERM");
+    const sigintHandler = () => onSignal("SIGINT");
+    process.on("SIGTERM", sigtermHandler);
+    process.on("SIGINT", sigintHandler);
+
+    child.on("error", onError);
+    child.on("exit", onExit);
   });
 }
 
@@ -437,6 +503,43 @@ interface ObservedOutcome {
   branchExists: boolean;
   hasCommits: boolean;
   commitCount: number;
+  pushable: boolean;
+}
+
+/**
+ * Parse the retry attempt number from a branch name like "fix/pixel-abc-retry-3".
+ * Returns 0 if no retry suffix is present.
+ */
+function parseRetryAttempt(branch: string | null): number {
+  if (!branch) return 0;
+  const m = branch.match(/-retry-(\d+)$/);
+  return m ? parseInt(m[1], 10) : 0;
+}
+
+/**
+ * Build the next branch name for a given base and the error's current branch field.
+ * If the current branch has no retry suffix or no such local branch exists, return
+ * the base name. Otherwise increment the attempt counter.
+ */
+function buildRetryBranch(
+  baseBranch: string,
+  currentBranch: string | null,
+  spawnFn: SpawnFn,
+  cwd: string,
+): Promise<string> {
+  const attempt = parseRetryAttempt(currentBranch ?? "");
+  if (attempt === 0) return Promise.resolve(baseBranch);
+  const candidate = `${baseBranch}-retry-${attempt + 1}`;
+  // Check if this branch already exists locally.
+  const child = spawnFn("git", ["show-ref", "--verify", `refs/heads/${candidate}`], {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    signal: AbortSignal.timeout(10_000),
+  });
+  return new Promise<{ branch: string; exists: boolean }>((resolve) => {
+    child.on("exit", (code) => resolve({ branch: candidate, exists: code === 0 }));
+    child.on("error", () => resolve({ branch: candidate, exists: false }));
+  }).then(({ exists }) => (exists ? `${baseBranch}-retry-${attempt + 1}` : baseBranch));
 }
 
 async function observeOutcome(
@@ -445,7 +548,8 @@ async function observeOutcome(
   spawnFn: SpawnFn,
 ): Promise<ObservedOutcome> {
   const exists = await runGit(cwd, ["show-ref", "--verify", `refs/heads/${branch}`], spawnFn);
-  if (exists.code !== 0) return { branchExists: false, hasCommits: false, commitCount: 0 };
+  if (exists.code !== 0)
+    return { branchExists: false, hasCommits: false, commitCount: 0, pushable: false };
 
   let baseBranch: string | null = null;
   for (const candidate of ["main", "master"]) {
@@ -455,11 +559,18 @@ async function observeOutcome(
       break;
     }
   }
-  if (!baseBranch) return { branchExists: true, hasCommits: false, commitCount: 0 };
+  if (!baseBranch)
+    return { branchExists: true, hasCommits: false, commitCount: 0, pushable: false };
 
   const ahead = await runGit(cwd, ["rev-list", "--count", `${baseBranch}..${branch}`], spawnFn);
   const count = ahead.code === 0 ? parseInt(ahead.stdout.trim(), 10) || 0 : 0;
-  return { branchExists: true, hasCommits: count > 0, commitCount: count };
+
+  // Check pushability via ls-remote.
+  const pushable = await runGit(cwd, ["ls-remote", "--heads", "origin", branch], spawnFn)
+    .then((r) => r.code === 0)
+    .catch(() => false);
+
+  return { branchExists: true, hasCommits: count > 0, commitCount: count, pushable };
 }
 
 interface GitResult {
@@ -470,7 +581,11 @@ interface GitResult {
 
 function runGit(cwd: string, args: string[], spawnFn: SpawnFn): Promise<GitResult> {
   return new Promise((resolve) => {
-    const child = spawnFn("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawnFn("git", args, {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      signal: AbortSignal.timeout(10_000),
+    });
     let stdout = "";
     let stderr = "";
     child.stdout?.on("data", (b: Buffer) => (stdout += b.toString()));

--- a/packages/ggcoder/src/core/pixel.ts
+++ b/packages/ggcoder/src/core/pixel.ts
@@ -94,7 +94,17 @@ export async function fetchPixelEntries(opts: ListOptions = {}): Promise<PixelFe
     try {
       const res = await fetchFn(`${ingestUrl}/api/projects/${id}/errors`, {
         headers: { authorization: `Bearer ${project.secret}` },
+        signal: AbortSignal.timeout(30_000),
       });
+      if (res.status === 401) {
+        console.warn(
+          chalk.hex("#fbbf24")(
+            `⚠ 401 for project ${project.name} — secret may need refresh. Run \`ggcoder pixel install\` to refresh.`,
+          ),
+        );
+        unreachable.push(project.name);
+        continue;
+      }
       if (!res.ok) {
         unreachable.push(project.name);
         continue;

--- a/packages/ggcoder/src/core/source-maps.ts
+++ b/packages/ggcoder/src/core/source-maps.ts
@@ -31,8 +31,10 @@ export interface StackFrame {
   in_app: boolean;
 }
 
+const DEBUG_BUILD = process.env.NODE_ENV !== "production";
 const COMMON_BUILD_DIRS = ["dist", "build", ".next", "out", "public", ".vite"];
 const MAX_DEPTH = 4;
+const MAX_ENTRIES = 50;
 
 interface MapCacheEntry {
   trace: TraceMap;
@@ -41,6 +43,7 @@ interface MapCacheEntry {
 
 export class SourceMapResolver {
   private readonly cache = new Map<string, MapCacheEntry | null>();
+  private readonly accessOrder: string[] = [];
 
   constructor(private readonly projectDir: string) {}
 
@@ -76,9 +79,21 @@ export class SourceMapResolver {
 
   private findMap(minifiedName: string): MapCacheEntry | null {
     const cached = this.cache.get(minifiedName);
-    if (cached !== undefined) return cached;
+    if (cached !== undefined) {
+      // Move to end (most recently used)
+      const idx = this.accessOrder.indexOf(minifiedName);
+      if (idx !== -1) this.accessOrder.splice(idx, 1);
+      this.accessOrder.push(minifiedName);
+      return cached;
+    }
     const result = this.searchForMap(minifiedName);
     this.cache.set(minifiedName, result);
+    this.accessOrder.push(minifiedName);
+    if (this.cache.size > MAX_ENTRIES) {
+      // Evict oldest (front of accessOrder)
+      const evictKey = this.accessOrder.shift()!;
+      this.cache.delete(evictKey);
+    }
     return result;
   }
 
@@ -91,6 +106,9 @@ export class SourceMapResolver {
     }
     const rootCandidate = join(this.projectDir, minifiedName + ".map");
     if (existsSync(rootCandidate)) return loadMap(rootCandidate);
+    if (DEBUG_BUILD) {
+      console.warn(`[source-maps] map not found for: ${minifiedName}`);
+    }
     return null;
   }
 }
@@ -135,7 +153,14 @@ function loadMap(mapPath: string): MapCacheEntry | null {
   try {
     const raw = readFileSync(mapPath, "utf8");
     const parsed = JSON.parse(raw) as object;
-    return { trace: new TraceMap(parsed as never), mapDir: dirname(mapPath) };
+    try {
+      return { trace: new TraceMap(parsed as never), mapDir: dirname(mapPath) };
+    } catch (parseErr) {
+      if (DEBUG_BUILD) {
+        console.warn("[source-maps] TraceMap parse failure:", parseErr);
+      }
+      return null;
+    }
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

Code quality fixes across gg-boss and ggcoder — all identified from architecture audit and cross-repo verification.

### gg-boss/telegram.ts — 5 fixes

| Fix | Impact |
|---|---|
| Move offset advancement inside the update loop, after each handleUpdate succeeds | P0 — throwing handlers no longer skip the next update |
| AbortSignal.timeout(35s) on getUpdates fetch | P0 — dead connections detected before Telegram's 30s server hold expires |
| Exponential back-off with ±20% jitter (1s→2s→4s… cap 30s), reset on success | P1 — faster recovery on transient network failures |
| parse_mode: "HTML" + toTelegramMarkdown rewritten to emit <b>/<i>/<code>/<pre>, strip GFM links | P1 — Markdown parse errors eliminated |
| DEBUG_BUILD-conditional console.warn on TraceMap parse failures | P1 — silent production failures surface in dev |

### ggcoder/source-maps.ts — 2 fixes

| Fix | Impact |
|---|---|
| LRU cache with MAX_ENTRIES=50 + eviction ordering | P2 — bounded memory growth for long-running boss instances |
| DEBUG_BUILD guard on TraceMap parse failures and map-not-found | P2 — debug signals in dev, silent in prod |

### ggcoder/pixel-fix.ts — 7 fixes

| Fix | Impact |
|---|---|
| AbortSignal.timeout(30s) on all fetch calls; 10s on all git spawns | P0 — all I/O bounded with timeouts |
| SIGTERM/SIGINT handler in runAgent that kills the child process | P0 — no zombie processes on container shutdown |
| Try/catch rollback in preparePixelFix reverts status to 'open' on any failure | P0 — failed fix attempts don't orphan the error in in_progress |
| 401 detection with re-install prompt in resolveErrorOwner and fetchPixelEntries | P1 — clear UX path when project secret is revoked |
| Dynamic retry branch naming fix/pixel-{id}-retry-{N} when prior branch exists | P2 — no more branch name collisions on retry |
| ls-remote pushability check in observeOutcome | P2 — distinguishes local-only from pushable branches |
| PrepareOptions extends FixOptions so spawnFn is accessible | P2 — TypeScript error fixed |

### ggcoder/pixel.ts — 2 fixes

| Fix | Impact |
|---|---|
| AbortSignal.timeout(30s) on fetchPixelEntries fetch | P0 |
| 401 detection with re-install prompt | P1 |

## Test plan

- [x] pnpm check — TypeScript clean across all packages (ggcoder 4.3.188)
- [x] pnpm lint — no lint errors
- [x] pnpm format:check — no formatting issues
- [x] pnpm test — 521/522 passing (1 pre-existing failure in compactor.test.ts, unrelated to these changes)