### PR TITLE
fix(ggcoder): main guard fails when invoked via npm-installed symlink

### DIFF
--- a/packages/ggcoder/src/cli.ts
+++ b/packages/ggcoder/src/cli.ts
@@ -2009,6 +2009,9 @@ function openBrowser(url: string): void {
   });
 }
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+if (
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === fs.realpathSync(path.resolve(process.argv[1]))
+) {
   main();
 }


### PR DESCRIPTION
## Summary

`ggcoder` exits silently with code 0 after a global npm install on macOS/Linux. The CLI never prints anything — not even `--version` or `--help`.

## Root cause

`packages/ggcoder/src/cli.ts:2012` (currently line 2012 on `main`):

```ts
if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
  main();
}
```

`npm i -g @kenkaiiii/ggcoder` installs a symlink:

```
~/.npm-global/bin/ggcoder -> ../lib/node_modules/@kenkaiiii/ggcoder/dist/cli.js
```

When Node loads the ESM entrypoint it follows the symlink, so:

- `fileURLToPath(import.meta.url)` → `…/lib/node_modules/@kenkaiiii/ggcoder/dist/cli.js` (realpath)
- `path.resolve(process.argv[1])` → `…/.npm-global/bin/ggcoder` (symlink path — `path.resolve` only normalizes, it doesn't resolve symlinks)

Equality fails → `main()` never runs → exit 0, no output.

## Reproduction

```sh
npm i -g @kenkaiiii/ggcoder
ggcoder --version       # silent, exit 0
node "$(realpath "$(command -v ggcoder)")" --version   # prints 4.3.218
```

Confirmed on macOS 26.1, Node 26.0.0, ggcoder 4.3.218.

## Fix

Wrap `process.argv[1]` in `fs.realpathSync` so both sides of the comparison are realpaths. `fs` is already imported at the top of `cli.ts`, so this is a one-line change with no new dependencies.

## Test plan

- [x] `ggcoder --version` now prints the version when invoked via the npm bin symlink
- [x] Direct invocation (`node packages/ggcoder/dist/cli.js`) still works (the realpath of a non-symlink is itself)
- [ ] Maintainer-side: verify on Linux and Windows (Windows uses `.cmd` shim, not a symlink — should be unaffected, but worth a quick check)