### PR TITLE
fix(gg-app): make chat file-path links open (grant opener path scope) + Finder reveal on Shift+click

### DIFF
--- a/gg-app/src-tauri/capabilities/default.json
+++ b/gg-app/src-tauri/capabilities/default.json
@@ -8,6 +8,14 @@
     "core:window:allow-start-dragging",
     "core:window:allow-close",
     "opener:default",
+    {
+      "identifier": "opener:allow-open-path",
+      "allow": [{ "path": "**" }]
+    },
+    {
+      "identifier": "opener:allow-reveal-item-in-dir",
+      "allow": [{ "path": "**" }]
+    },
     "log:default",
     "dialog:default",
     "updater:default",

--- a/gg-app/src-tauri/src/lib.rs
+++ b/gg-app/src-tauri/src/lib.rs
@@ -557,8 +557,10 @@ fn strip_file_location_suffix(path: &str) -> &str {
 
 /// Open a project file linked from the chat. Relative paths resolve against this
 /// window's sidecar cwd; `:line[:col]` and `#Lline` decorations are tolerated.
+/// With `reveal: true` (Shift/Cmd+click) the file is shown in the system file
+/// manager (Finder) instead of opened in its default application.
 #[tauri::command]
-fn open_project_path(webview: WebviewWindow, path: String) -> Result<(), String> {
+fn open_project_path(webview: WebviewWindow, path: String, reveal: Option<bool>) -> Result<(), String> {
     let cwd = cwd_for(&webview).ok_or("sidecar not ready")?;
     let trimmed = path.trim();
     if trimmed.is_empty() {
@@ -588,10 +590,18 @@ fn open_project_path(webview: WebviewWindow, path: String) -> Result<(), String>
         .canonicalize()
         .map_err(|_| format!("file not found: {}", cleaned))?;
 
-    webview
-        .opener()
-        .open_path(canonical.to_string_lossy().to_string(), None::<String>)
-        .map_err(|e| e.to_string())
+    let target = canonical.to_string_lossy().to_string();
+    if reveal.unwrap_or(false) {
+        webview
+            .opener()
+            .reveal_item_in_dir(target)
+            .map_err(|e| e.to_string())
+    } else {
+        webview
+            .opener()
+            .open_path(target, None::<String>)
+            .map_err(|e| e.to_string())
+    }
 }
 
 /// Proxy: current agent/session state.

--- a/gg-app/src/Markdown.tsx
+++ b/gg-app/src/Markdown.tsx
@@ -21,7 +21,8 @@ function isExternalHref(href: string): boolean {
 /**
  * Anchor that opens outside the webview. Browser links go to the OS browser;
  * file-ish links from the agent (`src/App.tsx`, `/abs/file.ts`, `file://…`) open
- * against the current project window's cwd.
+ * against the current project window's cwd. Shift/Cmd(Ctrl)+click reveals the
+ * file in the system file manager (Finder / Explorer) instead of opening it.
  */
 function ExternalLink({
   href,
@@ -39,7 +40,7 @@ function ExternalLink({
         if (isExternalHref(href)) {
           void openUrl(href);
         } else {
-          void openProjectPath(href);
+          void openProjectPath(href, e.shiftKey || e.metaKey || e.ctrlKey);
         }
       }}
     >

--- a/gg-app/src/agent.ts
+++ b/gg-app/src/agent.ts
@@ -240,7 +240,7 @@ export async function enhancePrompt(text: string): Promise<EnhanceResult> {
   return invoke<EnhanceResult>("agent_enhance_prompt", { text });
 }
 
-export async function openProjectPath(path: string): Promise<void> {
+export async function openProjectPath(path: string, reveal = false): Promise<void> {
   let decoded = path;
   try {
     decoded = decodeURIComponent(path);
@@ -248,7 +248,7 @@ export async function openProjectPath(path: string): Promise<void> {
     // Keep the original string if the model emitted a malformed `%` escape.
   }
   try {
-    await invoke("open_project_path", { path: decoded });
+    await invoke("open_project_path", { path: decoded, reveal });
   } catch (e) {
     await logError(`open_project_path failed: ${String(e)}`);
   }


### PR DESCRIPTION
## Problem

Clicking a file-path link in the chat does nothing. `open_project_path` (Rust) resolves the path and calls `webview.opener().open_path(...)`, but the app's capability only declares `opener:default` — which grants **open-url + reveal-item-in-dir + default-urls (http/https/mailto/tel)**. It does **not** grant `open-path`, and it provides **no filesystem path scope**. So the command is denied by the ACL at runtime; the error is caught and logged, and the click is a silent no-op.

## Fix

- **`capabilities/default.json`** — grant `opener:allow-open-path` and `opener:allow-reveal-item-in-dir`, each with a filesystem path scope (`"path": "**"`). This is the actual bug fix: it lets the existing `open_path` call succeed.
- **`open_project_path` (`lib.rs`)** — add a `reveal` flag: **Shift/Cmd/Ctrl+click** reveals the file in the OS file manager (Finder / Explorer) via `reveal_item_in_dir` instead of opening it in its default app. Plain click keeps the existing "open the file" behaviour.
- **`Markdown.tsx` / `agent.ts`** — thread the modifier through the existing `ExternalLink` click handler.

## Result

- **Plain click** on a file link → opens the file in its default app (now actually works).
- **Shift/Cmd+click** → reveals the file in Finder (folder opens, file selected).
- Web links are unchanged (still `openUrl` → browser).

## Notes

- Scope is `"path": "**"` (any path the agent references). A maintainer may prefer to tighten it to `"$HOME/**"`; project paths can live outside `$HOME` though (e.g. `/tmp`), so the broad scope matches the "open whatever the agent linked" intent.
- Verified end-to-end against a running 0.13.0 build via a runtime opener/reveal shim (proof-of-concept adapter) before writing this native fix — `reveal_item_in_dir` opens Finder as expected once the path scope is granted.
- Diff is 4 files / 28 insertions; no unrelated reformatting.
