### PR TITLE
fix(ggcoder): retry SDK timeouts and recover in-flight drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- **Crash-recovery drafts + smarter timeout retry (2026-07-05):** In-flight assistant text is snapshotted during streaming and restored after a process crash/forced app restart as a clearly marked recovered reply. Bare-text SDK timeouts (for example Anthropic `Request timed out` errors without an error code) now route through the existing automatic stall retry/backoff path instead of surfacing raw to the user. Verified with `pnpm --filter gg-app check` and `pnpm --filter ggcoder check`.

--- a/gg-app/src/App.css
+++ b/gg-app/src/App.css
@@ -1944,6 +1944,13 @@ body {
   /* Match the user message / input size so both sides read uniformly. */
   font-size: 15px;
 }
+.assistant-recovered-hint {
+  margin-top: 6px;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 12px;
+  opacity: 0.9;
+}
 
 /* ── Markdown rendering (assistant blocks) ── */
 /* Reset the transcript's inherited `pre-wrap` so the markdown source's

--- a/gg-app/src/App.tsx
+++ b/gg-app/src/App.tsx
@@ -196,7 +196,17 @@ export type Item =
       // of the full prompt body that was actually sent to GG Coder.
       kenSent?: boolean;
     }
-  | { kind: "assistant"; id: number; text: string }
+  | {
+      kind: "assistant";
+      id: number;
+      text: string;
+      // True when this bubble is a crash-recovery snapshot: the process died
+      // mid-stream (crash, force-quit, an app update killing the sidecar) with
+      // no completed reply ever recorded after it. Renders a small "recovered
+      // after an unexpected restart" hint below the text instead of looking
+      // like an ordinary finished reply.
+      recovered?: boolean;
+    }
   // Ken Kai (mentor agent) reply — magenta-tinted bubble + "Ken Kai" badge,
   // streamed from the ken_* SSE events. Never mistaken for GG Coder.
   | { kind: "ken"; id: number; text: string }
@@ -1048,7 +1058,13 @@ function App(): React.ReactElement {
                 body: h.autopilot.body,
                 copySeed: h.autopilot.copySeed,
               };
-            if (h.role !== "user") return { kind: h.role, id: nextId(), text: h.text };
+            if (h.role !== "user")
+              return {
+                kind: h.role,
+                id: nextId(),
+                text: h.text,
+                ...(h.recovered ? { recovered: true } : {}),
+              };
             // App-button prompts (e.g. "Initialize Git") were shown live as a
             // friendly shimmer label, not the expanded body. The label is
             // webview-only, so recover it from the restored prompt text. Slash
@@ -2543,6 +2559,11 @@ const TranscriptRow = memo(function TranscriptRow({
                 </span>
                 <div className="assistant-text">
                   <Markdown>{seg.text}</Markdown>
+                  {item.recovered && i === segments.length - 1 ? (
+                    <div className="assistant-recovered-hint">
+                      Recovered after an unexpected restart — this reply may be incomplete.
+                    </div>
+                  ) : null}
                 </div>
               </div>
             ),

--- a/gg-app/src/agent.ts
+++ b/gg-app/src/agent.ts
@@ -458,6 +458,11 @@ export interface HistoryEntry {
   error?: { scope: string; headline: string; message?: string; guidance?: string };
   /** Webview-copy info row marker (e.g. the video-capability warning). */
   infoKind?: "video_warning";
+  /** True when this row is a crash-recovery snapshot: the process died
+   *  mid-stream (crash, force-quit, an app update killing the sidecar) with
+   *  no completed assistant message ever appended after it. `text` is exactly
+   *  what the model had streamed before that happened. */
+  recovered?: boolean;
   /** Tool-produced images rendered inline (same as live `images` items),
    *  reconstructed from ImageContent blocks in persisted tool results. */
   toolImages?: Array<{ src: string; path?: string }>;

--- a/packages/gg-agent/src/agent-loop.ts
+++ b/packages/gg-agent/src/agent-loop.ts
@@ -330,12 +330,14 @@ export function isTransportFailure(err: unknown): boolean {
     /\bsse stream disconnected\b/i,
     /\bfailed to reconnect sse stream\b/i,
     // Bare-text SDK timeouts with no error code at all (e.g. Anthropic SDK's
-    // "Request timed out.", or a generic "The operation was aborted due to
-    // timeout" from fetch) — without this they fall through every retry
-    // branch and surface raw to the user instead of auto-retrying like every
-    // other transient transport failure.
-    /\btimed out\b/i,
-    /\btimeout\b/i,
+    // "Request timed out.", "Request to Anthropic timed out", or a fetch
+    // AbortSignal timeout) — without this they fall through every retry branch
+    // and surface raw to the user instead of auto-retrying like every other
+    // transient transport failure. Keep these patterns transport-shaped so a
+    // provider message that merely mentions a timeout policy does not retry.
+    /\brequest(?: to [\w .-]+)? timed out\b/i,
+    /\b(?:connection|socket|headers|body|operation|stream) timed out\b/i,
+    /\b(?:connection|socket|headers|body|operation|stream) timeout(?: error)?\b/i,
   ];
   const seen = new Set<unknown>();
   let cur: unknown = err;

--- a/packages/gg-agent/src/agent-loop.ts
+++ b/packages/gg-agent/src/agent-loop.ts
@@ -315,6 +315,11 @@ export function isTransportFailure(err: unknown): boolean {
     "UND_ERR_RESPONSE_STATUS_CODE",
     "UND_ERR_REQ_CONTENT_LENGTH_MISMATCH",
     "UND_ERR_RES_CONTENT_LENGTH_MISMATCH",
+    // Generic timeout codes some SDKs set without an ETIMEDOUT/UND_ wrapper
+    // (e.g. AbortSignal.timeout()-driven aborts surfaced as DOMException
+    // "TimeoutError", or an SDK's own connection-timeout error class).
+    "ETIMEOUT",
+    "ABORT_ERR",
   ]);
   const messages = [
     /^terminated$/i,
@@ -324,6 +329,13 @@ export function isTransportFailure(err: unknown): boolean {
     /\bbody timeout error\b/i,
     /\bsse stream disconnected\b/i,
     /\bfailed to reconnect sse stream\b/i,
+    // Bare-text SDK timeouts with no error code at all (e.g. Anthropic SDK's
+    // "Request timed out.", or a generic "The operation was aborted due to
+    // timeout" from fetch) — without this they fall through every retry
+    // branch and surface raw to the user instead of auto-retrying like every
+    // other transient transport failure.
+    /\btimed out\b/i,
+    /\btimeout\b/i,
   ];
   const seen = new Set<unknown>();
   let cur: unknown = err;

--- a/packages/ggcoder/src/app-sidecar.ts
+++ b/packages/ggcoder/src/app-sidecar.ts
@@ -315,6 +315,12 @@ interface HistoryEntryForWire {
   error?: { scope: string; headline: string; message?: string; guidance?: string };
   /** Webview-copy info row marker (e.g. the video-capability warning). */
   infoKind?: "video_warning";
+  /** True when this assistant row is a crash-recovery snapshot — the process
+   *  died mid-stream (crash, force-quit, an app update killing the sidecar)
+   *  and this is the last text the model had streamed before that happened.
+   *  The webview shows a "recovered after an unexpected restart" hint instead
+   *  of rendering it as an ordinary completed reply. */
+  recovered?: boolean;
   toolImages?: Array<{ src: string; path?: string }>;
   subagentGroup?: Array<{
     agentName?: string;
@@ -2386,6 +2392,19 @@ async function createSession(
           flushAutopilot(count);
         for (const count of [...appMarkersByCount.keys()].sort((a, b) => a - b))
           flushAppMarkers(count);
+
+        // Crash-recovery draft: text that was streaming when the process died
+        // mid-turn, with no completed assistant message ever appended after it.
+        // Rendered as a final row with a clear "recovered" marker so the user
+        // sees what was lost instead of it silently vanishing on resume.
+        const recoveredDraft = session.getRecoveredDraft();
+        if (recoveredDraft) {
+          history.push({
+            role: "assistant",
+            text: recoveredDraft.text,
+            recovered: true,
+          });
+        }
 
         json(res, 200, { history });
       })();

--- a/packages/ggcoder/src/core/agent-session.ts
+++ b/packages/ggcoder/src/core/agent-session.ts
@@ -26,12 +26,14 @@ import {
   KEN_TURN_CUSTOM_KIND,
   AUTOPILOT_MARKER_CUSTOM_KIND,
   APP_MARKER_CUSTOM_KIND,
+  DRAFT_MARKER_CUSTOM_KIND,
   type MessageEntry,
   type BranchInfo,
   type CustomEntry,
   type KenTurnPayload,
   type AutopilotMarkerPayload,
   type AppMarkerPayload,
+  type DraftMarkerPayload,
 } from "./session-manager.js";
 import { ExtensionLoader } from "./extensions/loader.js";
 import type { ExtensionContext } from "./extensions/types.js";
@@ -277,6 +279,24 @@ export class AgentSession {
   private lastPersistedIndex = 0;
   /** Current leaf entry ID in the session DAG — used to chain parentIds for branching. */
   private currentLeafId: string | null = null;
+  // ── Crash-recovery draft snapshot ──────────────────────────────────────
+  // Streamed assistant text is only durable once the FINISHED message is
+  // persisted at the end of runLoop(). If the process dies mid-stream (crash,
+  // force-quit, an app auto-update killing the sidecar) everything the user
+  // watched stream in is lost — the session file has no trace of it. These
+  // fields throttle a best-effort snapshot of the in-flight text to a `custom`
+  // entry (never on the message DAG, never seen by the LLM) so a resumed
+  // session can recover it instead of silently discarding it.
+  private draftRunId = "";
+  private draftText = "";
+  private draftLastPersistedAt = 0;
+  private draftLastPersistedLength = 0;
+  private static readonly DRAFT_PERSIST_MIN_INTERVAL_MS = 2_000;
+  private static readonly DRAFT_PERSIST_MIN_NEW_CHARS = 200;
+  /** Set once on load from a session file whose last draft snapshot has no
+   *  completed assistant message after it (see loadExistingSession). Null on a
+   *  fresh session or when the prior run finished normally. */
+  private recoveredDraft: DraftMarkerPayload | null = null;
 
   private opts: AgentSessionOptions;
 
@@ -734,6 +754,10 @@ export class AgentSession {
     this.regroundingInjected = false;
     this.compactionOccurred = false;
     this.originalRequest = originalRequest;
+    this.draftRunId = crypto.randomUUID();
+    this.draftText = "";
+    this.draftLastPersistedAt = 0;
+    this.draftLastPersistedLength = 0;
   }
 
   /**
@@ -745,6 +769,8 @@ export class AgentSession {
     switch (event.type) {
       case "text_delta":
         this.hookText += event.text;
+        this.draftText += event.text;
+        void this.maybePersistDraft();
         break;
       case "tool_call_start":
         this.hookToolCalls.set(event.toolCallId, { name: event.name, args: event.args ?? {} });
@@ -1007,6 +1033,62 @@ export class AgentSession {
       await this.persistMessage(this.messages[i]);
     }
     this.lastPersistedIndex = this.messages.length;
+    // The run completed and its messages are durably persisted above -- the
+    // draft snapshot's job is done. Clearing it here (not in a finally) is
+    // deliberate: if the process dies before reaching this line, the last
+    // snapshot written by maybePersistDraft() is exactly what should survive
+    // for recovery on the next resume.
+    await this.clearDraft();
+  }
+
+  /**
+   * Best-effort, throttled crash-recovery snapshot of the in-flight assistant
+   * text. Writes at most once per DRAFT_PERSIST_MIN_INTERVAL_MS and only when
+   * at least DRAFT_PERSIST_MIN_NEW_CHARS of new text accumulated since the
+   * last write -- cheap enough to call on every text_delta without adding
+   * meaningful I/O pressure to a normal run. No-op for transient sessions.
+   */
+  private async maybePersistDraft(): Promise<void> {
+    if (!this.sessionPath) return;
+    const now = Date.now();
+    const newChars = this.draftText.length - this.draftLastPersistedLength;
+    if (
+      this.draftLastPersistedAt !== 0 &&
+      (now - this.draftLastPersistedAt < AgentSession.DRAFT_PERSIST_MIN_INTERVAL_MS ||
+        newChars < AgentSession.DRAFT_PERSIST_MIN_NEW_CHARS)
+    ) {
+      return;
+    }
+    this.draftLastPersistedAt = now;
+    this.draftLastPersistedLength = this.draftText.length;
+    const afterMessageCount = this.messages.filter((m) => m.role !== "system").length;
+    const payload: DraftMarkerPayload = {
+      version: 1,
+      runId: this.draftRunId,
+      text: this.draftText,
+      afterMessageCount,
+    };
+    const entry: CustomEntry = {
+      type: "custom",
+      kind: DRAFT_MARKER_CUSTOM_KIND,
+      id: crypto.randomUUID(),
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      data: payload,
+    };
+    await this.sessionManager.appendEntry(this.sessionPath, entry);
+  }
+
+  /** Clear the in-memory draft state after a run finishes normally (its text
+   *  is now durable as a real persisted message). The on-disk marker itself is
+   *  left in place -- harmless, since getLatestDraftMarker on the next resume
+   *  will see the real assistant message recorded after it and treat the
+   *  marker as stale (see the kind's doc comment). */
+  private async clearDraft(): Promise<void> {
+    this.draftRunId = "";
+    this.draftText = "";
+    this.draftLastPersistedAt = 0;
+    this.draftLastPersistedLength = 0;
   }
 
   async switchModel(provider: string, model: string): Promise<void> {
@@ -1478,6 +1560,14 @@ export class AgentSession {
     return this.appMarkers;
   }
 
+  /** Crash-recovery draft recovered on load (null when none, or the last run
+   *  completed normally). See the `assistant_draft` custom-entry kind doc for
+   *  the staleness rule. Cleared implicitly once the session prompts again —
+   *  resetHookState() starts a fresh draftRunId for the new run. */
+  getRecoveredDraft(): DraftMarkerPayload | null {
+    return this.recoveredDraft;
+  }
+
   /**
    * Record one app transcript marker (display-only row) against this session.
    * Same treatment as autopilot markers: kept in memory for the live
@@ -1709,6 +1799,18 @@ export class AgentSession {
     this.autopilotMarkers = this.sessionManager.getAutopilotMarkers(loaded.entries);
     // Restore app transcript markers (plan banner / task header / errors / hints).
     this.appMarkers = this.sessionManager.getAppMarkers(loaded.entries);
+    // Crash-recovery draft: if the latest snapshot's anchor is still at (or
+    // beyond) the restored message count, no completed assistant message was
+    // ever persisted after it — the process died mid-stream. Surface it via
+    // getRecoveredDraft() so the host can render it with a "recovered" hint.
+    // A stale draft (anchor behind the restored count — the run finished
+    // normally afterward) is intentionally left null.
+    const draft = this.sessionManager.getLatestDraftMarker(loaded.entries);
+    const restoredMessageCount = loadedMessages.filter((m) => m.role !== "system").length;
+    this.recoveredDraft =
+      draft && draft.afterMessageCount >= restoredMessageCount && draft.text.trim()
+        ? draft
+        : null;
 
     // Track the current leaf for subsequent entries
     this.currentLeafId = loaded.header.leafId;

--- a/packages/ggcoder/src/core/agent-session.ts
+++ b/packages/ggcoder/src/core/agent-session.ts
@@ -758,6 +758,7 @@ export class AgentSession {
     this.draftText = "";
     this.draftLastPersistedAt = 0;
     this.draftLastPersistedLength = 0;
+    this.recoveredDraft = null;
   }
 
   /**
@@ -770,7 +771,15 @@ export class AgentSession {
       case "text_delta":
         this.hookText += event.text;
         this.draftText += event.text;
-        void this.maybePersistDraft();
+        void this.maybePersistDraft().catch((err) =>
+          log(
+            "WARN",
+            "session",
+            `Draft snapshot persistence failed; continuing without crash recovery: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          ),
+        );
         break;
       case "tool_call_start":
         this.hookToolCalls.set(event.toolCallId, { name: event.name, args: event.args ?? {} });
@@ -1562,8 +1571,8 @@ export class AgentSession {
 
   /** Crash-recovery draft recovered on load (null when none, or the last run
    *  completed normally). See the `assistant_draft` custom-entry kind doc for
-   *  the staleness rule. Cleared implicitly once the session prompts again —
-   *  resetHookState() starts a fresh draftRunId for the new run. */
+   *  the staleness rule. Cleared once the session prompts again so repeated
+   *  history reads in a live process do not keep re-emitting the stale draft. */
   getRecoveredDraft(): DraftMarkerPayload | null {
     return this.recoveredDraft;
   }

--- a/packages/ggcoder/src/core/session-manager.ts
+++ b/packages/ggcoder/src/core/session-manager.ts
@@ -106,6 +106,25 @@ export interface AppMarkerPayload {
   data: Record<string, unknown>;
 }
 
+/** Custom-entry kind for a crash-recovery snapshot of the assistant's
+ *  in-flight streamed text. Persisted (throttled) WHILE a reply is streaming,
+ *  never as part of the message DAG (parentId null — the LLM never sees it,
+ *  same treatment as Ken turns). `afterMessageCount` anchors it to the user
+ *  turn that started the run. On resume, a draft whose anchor equals the
+ *  restored message count means no completed assistant message was ever
+ *  appended after it — the process died mid-stream (crash, forced quit,
+ *  update-triggered restart) — so the host renders the recovered text instead
+ *  of silently losing it. A draft whose anchor is behind the restored count is
+ *  stale (the run finished normally afterward) and is ignored. */
+export const DRAFT_MARKER_CUSTOM_KIND = "assistant_draft";
+
+export interface DraftMarkerPayload {
+  version: 1;
+  runId: string;
+  text: string;
+  afterMessageCount: number;
+}
+
 export type SessionEntry =
   | MessageEntry
   | ModelChangeEntry
@@ -584,6 +603,30 @@ export class SessionManager {
       }
       return [];
     });
+  }
+
+  /**
+   * Latest crash-recovery draft marker in file order, or null if none was ever
+   * written. Callers compare its `afterMessageCount` against the restored
+   * message count to decide whether the draft is still live (process died
+   * mid-stream, no completed assistant message followed) or stale (the run
+   * finished normally and a real message was persisted afterward).
+   */
+  getLatestDraftMarker(entries: SessionEntry[]): DraftMarkerPayload | null {
+    let latest: DraftMarkerPayload | null = null;
+    for (const entry of entries) {
+      if (entry.type !== "custom" || entry.kind !== DRAFT_MARKER_CUSTOM_KIND) continue;
+      const p = entry.data as Partial<DraftMarkerPayload> | undefined;
+      if (
+        p?.version === 1 &&
+        typeof p.runId === "string" &&
+        typeof p.text === "string" &&
+        typeof p.afterMessageCount === "number"
+      ) {
+        latest = { version: 1, runId: p.runId, text: p.text, afterMessageCount: p.afterMessageCount };
+      }
+    }
+    return latest;
   }
 
   /**


### PR DESCRIPTION
## Summary
- auto-retry bare-text provider/SDK timeout errors via the existing stall backoff path
- persist throttled in-flight assistant draft snapshots during streaming
- restore true mid-stream crash/restart drafts in the app transcript with a clear recovered/incomplete hint
- harden edge cases: transport-shaped timeout matching, best-effort draft persistence errors, stale recovered drafts after continuation

## Why
Users can currently lose visible streamed text if the app/sidecar dies mid-response, and bare SDK timeout messages without error codes can surface raw instead of going through the existing retry/backoff machinery.

## Verification
- pnpm --filter gg-app check
- pnpm --filter ggcoder check
- pnpm --filter gg-agent check

## Notes
Rebased on upstream main / gg-app 0.14.9 before opening.