### PR TITLE
Fix Codex short-term usage meter toggle

### DIFF
--- a/gg-app/src/App.css
+++ b/gg-app/src/App.css
@@ -5077,7 +5077,7 @@ body {
   color: var(--text-secondary);
 }
 .title-usage-window {
-  width: 25px;
+  width: 29px;
   color: var(--text-muted);
   font-weight: 650;
   text-align: right;
@@ -5092,6 +5092,14 @@ body {
   border-radius: var(--radius-pill);
   background: radial-gradient(circle, #1b2735, #090a0f);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.45);
+}
+.title-usage-meter.is-unavailable .title-usage-track {
+  border-style: dashed;
+  background: var(--surface-1);
+  box-shadow: none;
+}
+.title-usage-meter.is-unavailable .title-usage-reset {
+  color: var(--text-muted);
 }
 .title-usage-fill {
   position: absolute;

--- a/gg-app/src/TitleUsageMeter.test.tsx
+++ b/gg-app/src/TitleUsageMeter.test.tsx
@@ -80,7 +80,7 @@ describe("TitleUsageMeter", () => {
     expect(getUsageMock).toHaveBeenCalledTimes(2);
   });
 
-  it("renders a weekly-only provider window without a bogus 168h label", async () => {
+  it("toggles a weekly-only Codex response to a truthful unavailable short-term view", async () => {
     getUsageMock.mockResolvedValue({
       provider: "openai",
       displayName: "Codex",
@@ -93,6 +93,7 @@ describe("TitleUsageMeter", () => {
           resetsAt: Date.now() + 6 * 24 * 60 * 60_000,
         },
       ],
+      unavailableWindowKinds: ["current"],
       fetchedAt: Date.now(),
     });
 
@@ -102,6 +103,40 @@ describe("TitleUsageMeter", () => {
     expect(screen.getByText("week")).toBeDefined();
     expect(screen.queryByText("168h")).toBeNull();
     expect(meter.querySelector<HTMLElement>(".title-usage-fill")?.style.width).toBe("11%");
+
+    fireEvent.click(meter);
+    await screen.findByRole("button", { name: /Codex Short-term: usage unavailable/ });
+    expect(screen.getByText("short")).toBeDefined();
+    expect(screen.getByText("unavailable")).toBeDefined();
+    expect(meter.querySelector(".title-usage-fill")).toBeNull();
+    expect(meter.className).toContain("is-unavailable");
+
+    fireEvent.click(meter);
+    await screen.findByRole("button", { name: /Codex Weekly: 11% used/ });
+  });
+
+  it("labels a preserved Codex short-term window as last known", async () => {
+    getUsageMock.mockResolvedValue({
+      provider: "openai",
+      displayName: "Codex",
+      connected: true,
+      windows: [
+        { kind: "current", label: "5-hour", usedPercent: 22 },
+        { kind: "weekly", label: "Weekly", usedPercent: 48 },
+      ],
+      unavailableWindowKinds: ["current"],
+      staleWindowKinds: ["current"],
+      fetchedAt: Date.now(),
+    });
+
+    render(<TitleUsageMeter currentProvider="openai" />);
+
+    const meter = await screen.findByRole("button", {
+      name: /Codex 5-hour: 22% used.*last known.*not included in the latest response/,
+    });
+    expect(meter.className).toContain("is-stale");
+    fireEvent.click(meter);
+    await screen.findByRole("button", { name: /Codex Weekly: 48% used/ });
   });
 
   it("keeps the last good snapshot when a refresh comes back unavailable", async () => {

--- a/gg-app/src/TitleUsageMeter.tsx
+++ b/gg-app/src/TitleUsageMeter.tsx
@@ -20,10 +20,10 @@ export function TitleUsageMeter({ currentProvider }: { currentProvider: string }
   const [snapshot, setSnapshot] = useState<SubscriptionUsageProviderSnapshot | null>(null);
   const [selection, setSelection] = useState<{
     provider: string;
-    kind: "current" | "weekly";
-  }>({ provider: currentProvider, kind: "current" });
+    kind: "current" | "weekly" | null;
+  }>({ provider: currentProvider, kind: null });
   const [now, setNow] = useState(() => Date.now());
-  const windowKind = selection.provider === currentProvider ? selection.kind : "current";
+  const windowKind = selection.provider === currentProvider ? selection.kind : null;
 
   // Never carry one provider's numbers over to another — clear on switch.
   useEffect(() => {
@@ -74,37 +74,65 @@ export function TitleUsageMeter({ currentProvider }: { currentProvider: string }
   }
 
   const selectedWindow =
-    snapshot.windows.find((window) => window.kind === windowKind) ?? snapshot.windows[0];
-  if (!selectedWindow) return null;
+    windowKind === null
+      ? snapshot.windows[0]
+      : snapshot.windows.find((window) => window.kind === windowKind);
+  const selectedKind = selectedWindow?.kind ?? windowKind;
+  if (!selectedKind) return null;
 
-  const canToggle = snapshot.windows.some((window) => window.kind !== selectedWindow.kind);
-  const percent = Math.min(100, Math.max(0, selectedWindow.usedPercent));
+  const nextKind = selectedKind === "current" ? "weekly" : "current";
+  const nextIsAvailable = snapshot.windows.some((window) => window.kind === nextKind);
+  const nextIsKnownUnavailable = snapshot.unavailableWindowKinds?.includes(nextKind) ?? false;
+  const canToggle = nextIsAvailable || nextIsKnownUnavailable;
+  const unavailable = !selectedWindow;
+  const staleWindow = snapshot.staleWindowKinds?.includes(selectedKind) ?? false;
+  const percent = selectedWindow
+    ? Math.min(100, Math.max(0, selectedWindow.usedPercent))
+    : 0;
   const roundedPercent = Math.round(percent);
-  const reset = compactResetLabel(selectedWindow.resetsAt, now);
-  const nextKind = selectedWindow.kind === "current" ? "weekly" : "current";
+  const reset = selectedWindow ? compactResetLabel(selectedWindow.resetsAt, now) : "unavailable";
+  const label = selectedWindow?.label ?? (selectedKind === "current" ? "Short-term" : "Weekly");
   // `stale` means the sidecar is replaying its last good snapshot because the
-  // provider's quota endpoint is failing (usually a 429). The bar deliberately
-  // stays put rather than flickering out, so say so on hover instead of
-  // presenting old numbers as live ones.
-  const title = `${snapshot.displayName} ${selectedWindow.label}: ${roundedPercent}% used · ${fullResetLabel(selectedWindow.resetsAt, now)}${snapshot.stale ? " · last known — usage is temporarily unavailable" : ""}${canToggle ? ` · Click for ${nextKind} usage` : ""}`;
+  // provider's quota endpoint is failing (usually a 429). A stale window is a
+  // recent value preserved from a partial response. Both remain visible, but
+  // are explicitly identified rather than presented as live numbers.
+  const status = unavailable
+    ? "usage unavailable"
+    : `${roundedPercent}% used · ${fullResetLabel(selectedWindow.resetsAt, now)}`;
+  const staleNote = snapshot.stale
+    ? " · last known — usage is temporarily unavailable"
+    : staleWindow
+      ? " · last known — this window was not included in the latest response"
+      : "";
+  const title = `${snapshot.displayName} ${label}: ${status}${staleNote}${canToggle ? ` · Click for ${nextKind} usage` : ""}`;
 
   return (
     <button
-      className={`title-usage-meter${snapshot.stale ? " is-stale" : ""}`}
+      className={`title-usage-meter${snapshot.stale || staleWindow ? " is-stale" : ""}${unavailable ? " is-unavailable" : ""}`}
       type="button"
       title={title}
       aria-label={title}
-      aria-pressed={selectedWindow.kind === "weekly"}
+      aria-pressed={selectedKind === "weekly"}
       onClick={() => canToggle && setSelection({ provider: currentProvider, kind: nextKind })}
     >
-      <span className="title-usage-window">{shortWindowLabel(selectedWindow)}</span>
+      <span className="title-usage-window">
+        {selectedWindow
+          ? shortWindowLabel(selectedWindow)
+          : selectedKind === "current"
+            ? "short"
+            : "week"}
+      </span>
       <span className="title-usage-track" aria-hidden="true">
-        <span className="title-usage-fill" style={{ width: `${percent}%` }} />
-        <span className="title-usage-particles">
-          {Array.from({ length: 5 }, (_, index) => (
-            <span className="title-usage-particle" key={index} />
-          ))}
-        </span>
+        {!unavailable && (
+          <>
+            <span className="title-usage-fill" style={{ width: `${percent}%` }} />
+            <span className="title-usage-particles">
+              {Array.from({ length: 5 }, (_, index) => (
+                <span className="title-usage-particle" key={`particle-${index}`} />
+              ))}
+            </span>
+          </>
+        )}
       </span>
       <span className="title-usage-reset">{reset}</span>
     </button>

--- a/gg-app/src/agent.ts
+++ b/gg-app/src/agent.ts
@@ -380,6 +380,10 @@ export interface SubscriptionUsageProviderSnapshot {
   windows: SubscriptionUsageWindow[];
   fetchedAt: number;
   error?: string;
+  /** Window kinds omitted from an otherwise valid provider response. */
+  unavailableWindowKinds?: Array<SubscriptionUsageWindow["kind"]>;
+  /** Window kinds preserved from a recent response rather than observed now. */
+  staleWindowKinds?: Array<SubscriptionUsageWindow["kind"]>;
   /** True when the sidecar is replaying its last good snapshot because the
    *  provider's quota endpoint is currently failing (usually a 429). */
   stale?: boolean;

--- a/packages/gg-core/src/provider-usage.test.ts
+++ b/packages/gg-core/src/provider-usage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { fetchSubscriptionUsage } from "./provider-usage.js";
+import { fetchSubscriptionUsage, mergePartialSubscriptionUsage } from "./provider-usage.js";
 import type { SubscriptionUsageError } from "./provider-usage.js";
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -138,6 +138,149 @@ describe("fetchSubscriptionUsage", () => {
         resetsAt: now + 593_701_000,
       },
     ]);
+    expect(result.unavailableWindowKinds).toEqual(["current"]);
+  });
+
+  it("uses an additional Codex 5-hour limit when the top level is weekly-only", async () => {
+    const result = await fetchSubscriptionUsage(
+      "openai",
+      { accessToken: "test-token" },
+      {
+        now: () => 1_000,
+        fetchFn: async () =>
+          jsonResponse({
+            rate_limit: {
+              primary_window: { limit_window_seconds: 604_800, used_percent: 12 },
+            },
+            additional_rate_limits: [
+              {
+                limit_name: "codex",
+                metered_feature: "tokens",
+                rate_limit: {
+                  primary_window: {
+                    limit_window_seconds: 18_000,
+                    used_percent: 27,
+                    reset_after_seconds: 300,
+                  },
+                },
+              },
+            ],
+          }),
+      },
+    );
+
+    expect(result.windows).toEqual([
+      {
+        kind: "current",
+        label: "5-hour",
+        usedPercent: 27,
+        resetsAt: 301_000,
+      },
+      { kind: "weekly", label: "Weekly", usedPercent: 12, resetsAt: undefined },
+    ]);
+    expect(result.unavailableWindowKinds).toBeUndefined();
+  });
+
+  it("ignores malformed and non-sub-week additional Codex limits", async () => {
+    const result = await fetchSubscriptionUsage(
+      "openai",
+      { accessToken: "test-token" },
+      {
+        fetchFn: async () =>
+          jsonResponse({
+            rate_limit: {
+              primary_window: { limit_window_seconds: 604_800, used_percent: 12 },
+            },
+            additional_rate_limits: [
+              null,
+              {},
+              { rate_limit: { primary_window: { used_percent: 33 } } },
+              {
+                rate_limit: {
+                  primary_window: { limit_window_seconds: 0, used_percent: 34 },
+                },
+              },
+              {
+                rate_limit: {
+                  primary_window: { limit_window_seconds: "18000", used_percent: 44 },
+                  secondary_window: { limit_window_seconds: 18_000, used_percent: "bad" },
+                },
+              },
+              {
+                rate_limit: {
+                  primary_window: { limit_window_seconds: 604_800, used_percent: 55 },
+                },
+              },
+            ],
+          }),
+      },
+    );
+
+    expect(result.windows).toEqual([
+      { kind: "weekly", label: "Weekly", usedPercent: 12, resetsAt: undefined },
+    ]);
+    expect(result.unavailableWindowKinds).toEqual(["current"]);
+  });
+
+  it("prefers the top-level Codex current window over additional limits", async () => {
+    const result = await fetchSubscriptionUsage(
+      "openai",
+      { accessToken: "test-token" },
+      {
+        fetchFn: async () =>
+          jsonResponse({
+            rate_limit: {
+              primary_window: { limit_window_seconds: 18_000, used_percent: 21 },
+              secondary_window: { limit_window_seconds: 604_800, used_percent: 40 },
+            },
+            additional_rate_limits: [
+              {
+                rate_limit: {
+                  primary_window: { limit_window_seconds: 10_800, used_percent: 99 },
+                  secondary_window: { limit_window_seconds: 604_800, used_percent: 88 },
+                },
+              },
+            ],
+          }),
+      },
+    );
+
+    expect(result.windows).toEqual([
+      { kind: "current", label: "5-hour", usedPercent: 21, resetsAt: undefined },
+      { kind: "weekly", label: "Weekly", usedPercent: 40, resetsAt: undefined },
+    ]);
+  });
+
+  it("preserves a recent Codex short-term window without extending its lifetime", () => {
+    const cached = new Map();
+    const complete = {
+      provider: "openai" as const,
+      displayName: "Codex",
+      windows: [
+        { kind: "current" as const, label: "5-hour", usedPercent: 22 },
+        { kind: "weekly" as const, label: "Weekly", usedPercent: 40 },
+      ],
+      fetchedAt: 1_000,
+    };
+    mergePartialSubscriptionUsage(complete, cached, 1_000, 30_000);
+
+    const partial = {
+      provider: "openai" as const,
+      displayName: "Codex",
+      windows: [{ kind: "weekly" as const, label: "Weekly", usedPercent: 41 }],
+      fetchedAt: 2_000,
+      unavailableWindowKinds: ["current" as const],
+    };
+    const merged = mergePartialSubscriptionUsage(partial, cached, 2_000, 30_000);
+    expect(merged.windows).toEqual([
+      { kind: "current", label: "5-hour", usedPercent: 22 },
+      { kind: "weekly", label: "Weekly", usedPercent: 41 },
+    ]);
+    expect(merged.staleWindowKinds).toEqual(["current"]);
+
+    const expired = mergePartialSubscriptionUsage(partial, cached, 31_000, 30_000);
+    expect(expired.windows).toEqual([{ kind: "weekly", label: "Weekly", usedPercent: 41 }]);
+    expect(expired.staleWindowKinds).toBeUndefined();
   });
 
   it("normalizes Kimi weekly quota and the 5-hour rate-limit window", async () => {

--- a/packages/gg-core/src/provider-usage.ts
+++ b/packages/gg-core/src/provider-usage.ts
@@ -16,6 +16,50 @@ export interface SubscriptionUsageSnapshot {
   displayName: string;
   windows: SubscriptionUsageWindow[];
   fetchedAt: number;
+  /** Window kinds the provider omitted from an otherwise valid response. */
+  unavailableWindowKinds?: Array<SubscriptionUsageWindow["kind"]>;
+  /** Window kinds preserved from a recent response rather than observed now. */
+  staleWindowKinds?: Array<SubscriptionUsageWindow["kind"]>;
+}
+
+export interface CachedSubscriptionUsageWindow {
+  window: SubscriptionUsageWindow;
+  observedAt: number;
+}
+
+/**
+ * Preserve recently observed windows when a provider returns a partial quota
+ * response. The original observation time is retained so repeated partial
+ * responses cannot keep old data alive indefinitely.
+ */
+export function mergePartialSubscriptionUsage(
+  snapshot: SubscriptionUsageSnapshot,
+  cached: Map<SubscriptionUsageWindow["kind"], CachedSubscriptionUsageWindow>,
+  now: number,
+  maxAgeMs: number,
+): SubscriptionUsageSnapshot {
+  for (const window of snapshot.windows) cached.set(window.kind, { window, observedAt: now });
+
+  const unavailable = new Set(snapshot.unavailableWindowKinds ?? []);
+  const staleWindowKinds: Array<SubscriptionUsageWindow["kind"]> = [];
+  const windows = [...snapshot.windows];
+  for (const kind of unavailable) {
+    const previous = cached.get(kind);
+    if (!previous || now - previous.observedAt >= maxAgeMs) {
+      cached.delete(kind);
+      continue;
+    }
+    if (!windows.some((window) => window.kind === kind)) {
+      windows.push(previous.window);
+      staleWindowKinds.push(kind);
+    }
+  }
+  windows.sort((left, right) => (left.kind === right.kind ? 0 : left.kind === "current" ? -1 : 1));
+  return {
+    ...snapshot,
+    windows,
+    ...(staleWindowKinds.length > 0 ? { staleWindowKinds } : {}),
+  };
 }
 
 export class SubscriptionUsageError extends Error {
@@ -54,11 +98,20 @@ interface CodexWindow {
   reset_after_seconds?: unknown;
 }
 
+interface CodexRateLimit {
+  primary_window?: CodexWindow | null;
+  secondary_window?: CodexWindow | null;
+}
+
+interface CodexAdditionalRateLimit {
+  limit_name?: unknown;
+  metered_feature?: unknown;
+  rate_limit?: CodexRateLimit | null;
+}
+
 interface CodexUsageResponse {
-  rate_limit?: {
-    primary_window?: CodexWindow | null;
-    secondary_window?: CodexWindow | null;
-  } | null;
+  rate_limit?: CodexRateLimit | null;
+  additional_rate_limits?: CodexAdditionalRateLimit[] | null;
 }
 
 interface KimiUsageDetail {
@@ -226,19 +279,49 @@ async function fetchCodexUsage(
   if (credentials.accountId) headers["ChatGPT-Account-Id"] = credentials.accountId;
   const response = await fetchFn(CODEX_USAGE_URL, { method: "GET", signal, headers });
   const data = (await readUsageResponse(response, now())) as CodexUsageResponse;
-  const windows = [
+  const topLevelWindows = [
     normalizedCodexWindow(data.rate_limit?.primary_window, "current", now()),
     normalizedCodexWindow(data.rate_limit?.secondary_window, "weekly", now()),
   ].filter((window): window is SubscriptionUsageWindow => window !== null);
-  windows.sort((left, right) => {
-    if (left.kind === right.kind) return 0;
-    return left.kind === "current" ? -1 : 1;
-  });
+  let current = topLevelWindows.find((window) => window.kind === "current");
+  const weekly = topLevelWindows.find((window) => window.kind === "weekly");
+
+  // Some wham responses move the short-term quota under a feature-specific
+  // additional_rate_limits entry while leaving only the weekly plan window at
+  // the top level. Use the first genuinely sub-week window, but never let an
+  // additional limit replace a top-level current or weekly value.
+  if (!current && Array.isArray(data.additional_rate_limits)) {
+    for (const additional of data.additional_rate_limits) {
+      const candidates = [
+        additional?.rate_limit?.primary_window,
+        additional?.rate_limit?.secondary_window,
+      ];
+      for (const candidate of candidates) {
+        const duration = finiteNumber(candidate?.limit_window_seconds);
+        if (duration === undefined || duration <= 0 || duration >= 6 * 24 * 60 * 60) continue;
+        const normalized = normalizedCodexWindow(candidate, "current", now());
+        if (normalized?.kind === "current") {
+          current = normalized;
+          break;
+        }
+      }
+      if (current) break;
+    }
+  }
+
+  const windows = [current, weekly].filter(
+    (window): window is SubscriptionUsageWindow => window !== undefined,
+  );
+  const availableKinds = new Set(windows.map((window) => window.kind));
+  const unavailableWindowKinds = (["current", "weekly"] as const).filter(
+    (kind) => !availableKinds.has(kind),
+  );
   return {
     provider: "openai",
     displayName: "Codex",
     windows,
     fetchedAt: now(),
+    ...(unavailableWindowKinds.length > 0 ? { unavailableWindowKinds } : {}),
   };
 }
 

--- a/packages/ggcoder/src/app-sidecar.ts
+++ b/packages/ggcoder/src/app-sidecar.ts
@@ -79,6 +79,7 @@ import { cleanupToolOutputs } from "./tools/overflow.js";
 import { readCappedBody } from "./utils/http-body.js";
 import {
   fetchSubscriptionUsage,
+  mergePartialSubscriptionUsage,
   MOONSHOT_OAUTH_KEY,
   SubscriptionUsageError,
   XIAOMI_CREDITS_KEY,
@@ -90,6 +91,7 @@ import {
   toModelInfo as localModelInfo,
   type LocalEndpoint,
   type LocalEndpointProbe,
+  type CachedSubscriptionUsageWindow,
   type SubscriptionUsageProvider,
   type SubscriptionUsageSnapshot,
 } from "@kenkaiiii/gg-core";
@@ -879,8 +881,13 @@ async function main(): Promise<void> {
       ctx.broadcast("progress", { ...snapshot, origin: ctx.id === originId });
   });
 
+  type ConnectedUsageResult = SubscriptionUsageSnapshot & {
+    connected: true;
+    error?: never;
+    stale?: boolean;
+  };
   type UsageResult =
-    | (SubscriptionUsageSnapshot & { connected: true; error?: never; stale?: boolean })
+    | ConnectedUsageResult
     | {
         provider: SubscriptionUsageProvider;
         displayName: string;
@@ -895,12 +902,19 @@ async function main(): Promise<void> {
     { expiresAt: number; result: UsageResult }
   >();
   const usageRequests = new Map<SubscriptionUsageProvider, Promise<UsageResult>>();
+  // Keep each window's original observation time. Codex's wham endpoint can
+  // temporarily return only the weekly window; a new weekly response must not
+  // make an old short-term value look fresh forever.
+  const usageWindowCache = new Map<
+    SubscriptionUsageProvider,
+    Map<"current" | "weekly", CachedSubscriptionUsageWindow>
+  >();
   // Last snapshot that actually carried windows, per provider. Replayed while a
   // fetch is failing so the title meter never blinks out of existence. Bounded
   // by USAGE_LAST_GOOD_MAX_AGE_MS — a provider that never recovers must stop
   // reporting rather than freeze a percentage (and a long-past reset time) on
   // screen forever. The 429 backoff alone runs to 24h, far past any usefulness.
-  const usageLastGood = new Map<SubscriptionUsageProvider, UsageResult>();
+  const usageLastGood = new Map<SubscriptionUsageProvider, ConnectedUsageResult>();
   const USAGE_LAST_GOOD_MAX_AGE_MS = 30 * 60_000;
   // 429 backoff: quota endpoints are auxiliary UI data. Honor Retry-After when
   // provided; otherwise retain the unavailable snapshot for 30 minutes. Clamp
@@ -921,13 +935,22 @@ async function main(): Promise<void> {
       // Logged out: drop the replay cache so a later login on a DIFFERENT
       // account can never inherit the previous one's numbers.
       usageLastGood.delete(provider);
+      usageWindowCache.delete(provider);
       return { provider, displayName, connected: false, windows: [], fetchedAt: Date.now() };
     }
     try {
       let credentials = await auth.resolveCredentials(authKey);
       try {
+        const fetched = await fetchSubscriptionUsage(provider, credentials);
+        const cache = usageWindowCache.get(provider) ?? new Map();
+        usageWindowCache.set(provider, cache);
         const snapshot = {
-          ...(await fetchSubscriptionUsage(provider, credentials)),
+          ...mergePartialSubscriptionUsage(
+            fetched,
+            cache,
+            Date.now(),
+            USAGE_LAST_GOOD_MAX_AGE_MS,
+          ),
           connected: true as const,
         };
         usageRateLimitedUntil.delete(provider);
@@ -937,8 +960,16 @@ async function main(): Promise<void> {
         // once on 401, matching inference auth recovery, then retry the usage call.
         if (error instanceof SubscriptionUsageError && error.status === 401) {
           credentials = await auth.resolveCredentials(authKey, { forceRefresh: true });
+          const fetched = await fetchSubscriptionUsage(provider, credentials);
+          const cache = usageWindowCache.get(provider) ?? new Map();
+          usageWindowCache.set(provider, cache);
           const snapshot = {
-            ...(await fetchSubscriptionUsage(provider, credentials)),
+            ...mergePartialSubscriptionUsage(
+              fetched,
+              cache,
+              Date.now(),
+              USAGE_LAST_GOOD_MAX_AGE_MS,
+            ),
             connected: true as const,
           };
           usageRateLimitedUntil.delete(provider);
@@ -978,7 +1009,26 @@ async function main(): Promise<void> {
       if (lastGood && Date.now() - lastGood.fetchedAt >= USAGE_LAST_GOOD_MAX_AGE_MS) {
         usageLastGood.delete(provider);
       } else if (connected && lastGood) {
-        return { ...lastGood, stale: true };
+        const staleKinds = new Set(lastGood.staleWindowKinds ?? []);
+        const windowCache = usageWindowCache.get(provider);
+        const windows = lastGood.windows.filter((window) => {
+          if (!staleKinds.has(window.kind)) return true;
+          const observed = windowCache?.get(window.kind);
+          return (
+            observed !== undefined &&
+            Date.now() - observed.observedAt < USAGE_LAST_GOOD_MAX_AGE_MS
+          );
+        });
+        if (windows.length > 0) {
+          return {
+            ...lastGood,
+            windows,
+            staleWindowKinds: lastGood.staleWindowKinds?.filter((kind) =>
+              windows.some((window) => window.kind === kind),
+            ),
+            stale: true,
+          };
+        }
       }
       return {
         provider,
@@ -1003,7 +1053,7 @@ async function main(): Promise<void> {
       // Never re-store a replay — it would keep its original `fetchedAt`, but
       // writing it back muddies the "last GOOD" contract for no gain.
       if (result.connected && !result.error && !result.stale && result.windows.length > 0) {
-        usageLastGood.set(provider, result);
+        usageLastGood.set(provider, result as ConnectedUsageResult);
       }
       // Anthropic can return utilization before it assigns reset timestamps
       // (notably before the account's first active request). Retry that partial


### PR DESCRIPTION
## Summary

Fixes the title-bar usage meter when Codex returns a weekly-only top-level `rate_limit` response.

Today the meter still renders as an enabled button and the global click sound plays, but `canToggle` is false because the normalized snapshot contains no `current` window. The click therefore appears broken and the user cannot inspect short-term usage.

## Root cause

The Codex normalizer only reads:

- `rate_limit.primary_window`
- `rate_limit.secondary_window`

Some responses can leave only a weekly window at the top level while exposing a real sub-week window in `additional_rate_limits[]`. Partial responses can also temporarily replace a previously complete current+weekly snapshot.

## Changes

- Parse `additional_rate_limits[]` and use the first valid sub-week window only when top-level current usage is absent.
- Keep top-level current and weekly values authoritative.
- Reject malformed, zero/negative-duration, non-numeric, and weekly additional windows.
- Mark omitted window kinds explicitly.
- Preserve recently observed missing windows for at most 30 minutes without refreshing their original observation time.
- Clear preserved usage on logout and prune expired values from error replays.
- Allow the meter to toggle from weekly to the short-term view even when the latest response omitted it.
- Label preserved values as `last known`.
- If no real or preserved short-term value exists, show `5h · unavailable` rather than fabricating usage.

## User-visible behavior

Before:

```text
week → click sound → no change
```

After:

```text
week → 5h short-term usage → week
```

If Codex provides no usable short-term value anywhere:

```text
week → 5h unavailable → week
```

## Verification

- `@kenkaiiii/gg-core`: 109 tests passed
- `gg-app`: 296 tests passed
- gg-core TypeScript check passed
- ggcoder TypeScript check passed
- gg-app TypeScript check passed
- ESLint passed
- `git diff --check` passed
