### PR TITLE
fix(ggcoder): forward MCP image content parts to the model

### DIFF
--- a/.changeset/mcp-image-content.md
+++ b/.changeset/mcp-image-content.md
@@ -1,0 +1,5 @@
+---
+"@kenkaiiii/ggcoder": patch
+---
+
+Forward MCP image content to the model. Tool responses containing `type: "image"` parts (or embedded resources with an image blob) were reduced to their text parts, so an image-only tool such as a screenshot or design-export server returned `(empty response)`.

--- a/packages/ggcoder/src/core/mcp/client.ts
+++ b/packages/ggcoder/src/core/mcp/client.ts
@@ -12,7 +12,8 @@ import {
   UnauthorizedError,
 } from "@modelcontextprotocol/client";
 import type { ElicitRequest, ElicitResult } from "@modelcontextprotocol/client";
-import type { AgentTool } from "@kenkaiiii/gg-agent";
+import type { AgentTool, ToolExecuteResult } from "@kenkaiiii/gg-agent";
+import type { ImageContent, TextContent } from "@kenkaiiii/gg-ai";
 import { z } from "zod";
 import http from "node:http";
 import os from "node:os";
@@ -27,6 +28,87 @@ import { McpOAuthStore } from "./oauth-store.js";
 import { isLocalhost, alternateLoopback, isNetworkError } from "./loopback.js";
 import { resolveStdioCommand } from "./resolve-stdio.js";
 import { McpCatalogCache, type ProtocolEra } from "./catalog-cache.js";
+
+/** Media types the providers accept as inline image input. An MCP server may
+ *  legitimately return `image/svg+xml` or a TIFF; those cannot be forwarded, so
+ *  they degrade to a text note instead of being dropped silently. */
+const FORWARDABLE_IMAGE_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
+
+/**
+ * Convert an MCP `CallToolResult.content` array into a tool result the agent
+ * loop can hand to the model.
+ *
+ * Text parts pass through unchanged. Image parts (`{ type: "image", data,
+ * mimeType }`) become real {@link ImageContent} so a tool whose entire answer IS
+ * a picture — a screenshot tool, a chart renderer, a design-file exporter —
+ * actually reaches the model. Before this, only `item.text` was collected, so
+ * an image-only response arrived as `(empty response)` and the model was asked
+ * to reason about a picture it never received.
+ *
+ * Anything unmappable is reported as a short text note rather than dropped, so
+ * a silent hole never looks like an empty tool.
+ */
+export async function mcpContentToToolResult(
+  content: readonly unknown[],
+): Promise<ToolExecuteResult> {
+  const parts: (TextContent | ImageContent)[] = [];
+
+  for (const item of content) {
+    if (item == null || typeof item !== "object") continue;
+    const part = item as Record<string, unknown>;
+
+    if (typeof part.text === "string") {
+      parts.push({ type: "text", text: part.text });
+      continue;
+    }
+
+    if (part.type === "image" && typeof part.data === "string") {
+      const mediaType = typeof part.mimeType === "string" ? part.mimeType : "image/png";
+      if (!FORWARDABLE_IMAGE_TYPES.has(mediaType)) {
+        parts.push({ type: "text", text: `(MCP returned an unsupported image type: ${mediaType})` });
+        continue;
+      }
+      parts.push(await fitImagePart(part.data, mediaType));
+      continue;
+    }
+
+    // `{ type: "resource", resource: { text | blob } }` — embedded resources.
+    const resource = part.resource;
+    if (resource != null && typeof resource === "object") {
+      const res = resource as Record<string, unknown>;
+      if (typeof res.text === "string") {
+        parts.push({ type: "text", text: res.text });
+        continue;
+      }
+      const mediaType = typeof res.mimeType === "string" ? res.mimeType : "";
+      if (typeof res.blob === "string" && FORWARDABLE_IMAGE_TYPES.has(mediaType)) {
+        parts.push(await fitImagePart(res.blob, mediaType));
+        continue;
+      }
+    }
+  }
+
+  if (parts.length === 0) return "(empty response)";
+  // Text-only stays a plain string: the existing transcript, truncation and
+  // display paths all handle strings, and nothing gains from wrapping them.
+  if (parts.every((p) => p.type === "text")) {
+    return parts.map((p) => (p as TextContent).text).join("\n") || "(empty response)";
+  }
+  return { content: parts };
+}
+
+/** Downscale an MCP image to the provider's visual budget. Sharp is optional at
+ *  runtime, and a server may hand back something it cannot decode, so any
+ *  failure forwards the original bytes rather than losing the image. */
+async function fitImagePart(base64: string, mediaType: string): Promise<ImageContent> {
+  try {
+    const { shrinkToFit } = await import("../../utils/image.js");
+    const fitted = await shrinkToFit(Buffer.from(base64, "base64"), mediaType);
+    return { type: "image", mediaType: fitted.mediaType, data: fitted.buffer.toString("base64") };
+  } catch {
+    return { type: "image", mediaType, data: base64 };
+  }
+}
 
 interface ConnectedServer {
   name: string;
@@ -569,7 +651,7 @@ export class MCPClientManager {
           // The client the attempt actually ran against, so a failure can be
           // attributed to "my client was replaced" vs "the server hung up".
           let attemptClient = liveClient();
-          const callOnce = async (): Promise<string> => {
+          const callOnce = async (): Promise<ToolExecuteResult> => {
             attemptClient = liveClient();
             const result = await attemptClient.callTool(
               { name: tool.name, arguments: args as Record<string, unknown> },
@@ -578,18 +660,7 @@ export class MCPClientManager {
             if (!("content" in result) || !Array.isArray(result.content)) {
               return "(empty response)";
             }
-            const texts: string[] = [];
-            for (const item of result.content) {
-              if (
-                item != null &&
-                typeof item === "object" &&
-                "text" in item &&
-                typeof item.text === "string"
-              ) {
-                texts.push(item.text);
-              }
-            }
-            return texts.join("\n") || "(empty response)";
+            return mcpContentToToolResult(result.content);
           };
 
           try {

--- a/packages/ggcoder/src/core/mcp/content.test.ts
+++ b/packages/ggcoder/src/core/mcp/content.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import { mcpContentToToolResult } from "./client.js";
+
+// A 1x1 PNG. Small enough that shrinkToFit is a no-op if sharp is present, and
+// harmless if it is not (the helper falls back to the original bytes).
+const PNG_1X1 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+describe("mcpContentToToolResult", () => {
+  it("returns a plain string for text-only content", async () => {
+    const result = await mcpContentToToolResult([
+      { type: "text", text: "first" },
+      { type: "text", text: "second" },
+    ]);
+    expect(result).toBe("first\nsecond");
+  });
+
+  it("forwards an image-only response as image content", async () => {
+    const result = await mcpContentToToolResult([
+      { type: "image", data: PNG_1X1, mimeType: "image/png" },
+    ]);
+    expect(typeof result).toBe("object");
+    const content = (result as { content: unknown[] }).content;
+    expect(content).toHaveLength(1);
+    expect(content[0]).toMatchObject({ type: "image", mediaType: "image/png" });
+  });
+
+  it("keeps text and image parts in order when both are present", async () => {
+    const result = await mcpContentToToolResult([
+      { type: "text", text: "screenshot of the frame" },
+      { type: "image", data: PNG_1X1, mimeType: "image/jpeg" },
+    ]);
+    const content = (result as { content: Array<{ type: string }> }).content;
+    expect(content.map((p) => p.type)).toEqual(["text", "image"]);
+  });
+
+  it("reads text out of an embedded resource", async () => {
+    const result = await mcpContentToToolResult([
+      { type: "resource", resource: { uri: "file:///a.txt", text: "body" } },
+    ]);
+    expect(result).toBe("body");
+  });
+
+  it("forwards an image blob carried by an embedded resource", async () => {
+    const result = await mcpContentToToolResult([
+      {
+        type: "resource",
+        resource: { uri: "file:///a.png", mimeType: "image/png", blob: PNG_1X1 },
+      },
+    ]);
+    const content = (result as { content: Array<{ type: string }> }).content;
+    expect(content[0]?.type).toBe("image");
+  });
+
+  it("notes an unsupported image type instead of dropping it", async () => {
+    const result = await mcpContentToToolResult([
+      { type: "image", data: "PHN2Zz48L3N2Zz4=", mimeType: "image/svg+xml" },
+    ]);
+    expect(result).toContain("image/svg+xml");
+  });
+
+  it("still reports an empty response when nothing is mappable", async () => {
+    expect(await mcpContentToToolResult([])).toBe("(empty response)");
+    expect(await mcpContentToToolResult([{ type: "audio", data: "x" }])).toBe("(empty response)");
+  });
+
+  it("ignores malformed entries without throwing", async () => {
+    const result = await mcpContentToToolResult([null, 42, { type: "image" }, { text: "ok" }]);
+    expect(result).toBe("ok");
+  });
+
+  it("does not lose the image when downscaling fails", async () => {
+    vi.resetModules();
+    const result = await mcpContentToToolResult([
+      { type: "image", data: "not-valid-base64-image", mimeType: "image/png" },
+    ]);
+    const content = (result as { content: Array<{ type: string; data: string }> }).content;
+    expect(content[0]?.type).toBe("image");
+    expect(content[0]?.data).toBe("not-valid-base64-image");
+  });
+});


### PR DESCRIPTION
## Problem

An MCP tool response is reduced to its text parts before it reaches the model. In `packages/ggcoder/src/core/mcp/client.ts` the tool `execute` collected `item.text` and joined it; every other content part was discarded.

Consequences:

- A tool whose entire answer is an image (screenshot servers, chart renderers, design-file exporters) returns `(empty response)`.
- The model is then asked to reason about a picture it never received, and usually invents one.
- Embedded resources (`{ type: "resource", resource: { text | blob } }`) were dropped as well, including their text.

Reported on Mac (M4) with `flaude` and `refero` registered as generic MCP servers; reproducible against any server that returns an image-only result.

## Change

`mcpContentToToolResult()` maps an MCP `content` array to a tool result:

- `text` parts pass through.
- `image` parts become `ImageContent` (base64 + media type), downscaled through the existing `utils/image.ts` `shrinkToFit` so provider image limits are respected — the same path `tools/screenshot.ts` already uses.
- Embedded resources contribute their `text`, or their `blob` when it carries a forwardable image type.
- Unsupported image types (`image/svg+xml`, TIFF, …) degrade to a short text note instead of vanishing.

Text-only responses still return a plain `string`, so transcript, truncation and display paths are unchanged. Only mixed or image-bearing responses become a `StructuredToolResult`, which the agent loop already accepts (`ToolExecuteResult`).

Downscaling failures (sharp missing, undecodable bytes) forward the original image rather than losing it.

## Verification

- `pnpm --filter @kenkaiiii/ggcoder test src/core/mcp` — 114 passed, 3 skipped, including 9 new cases in `src/core/mcp/content.test.ts`.
- `tsc --noEmit` clean for `packages/ggcoder`.
- `eslint` clean for both touched files.

New tests cover: text-only, image-only, mixed ordering, resource text, resource image blob, unsupported media type, empty/unmappable content, malformed entries, and the downscale-failure fallback.
