### PR TITLE
refactor(gg-core): route tier lookups through one getModelForTier

### DIFF
--- a/packages/gg-core/src/model-registry.test.ts
+++ b/packages/gg-core/src/model-registry.test.ts
@@ -13,6 +13,7 @@ import {
   getDefaultModel,
   getDefaultThinkingLevel,
   getFastModel,
+  getModelForTier,
   getModelsForProvider,
   getSummaryModel,
   getToolResultCharLimit,
@@ -111,6 +112,47 @@ describe("getFastModel", () => {
   it("picks Haiku for Anthropic and Luna for OpenAI", () => {
     expect(getFastModel("anthropic", "claude-opus-5").costTier).toBe("low");
     expect(getFastModel("openai", "gpt-5.6-sol").id).toBe("gpt-5.6-luna");
+  });
+});
+
+describe("getModelForTier", () => {
+  const TIERS = ["low", "medium", "high"] as const;
+
+  it("returns a model at the requested tier when the provider has one", () => {
+    for (const provider of PROVIDERS) {
+      const current = getDefaultModel(provider);
+      for (const tier of TIERS) {
+        const picked = getModelForTier(provider, current.id, tier);
+        const hasTier = getModelsForProvider(provider).some((m) => m.costTier === tier);
+        if (hasTier) {
+          expect(picked.costTier).toBe(tier);
+        } else {
+          // No sibling in that band — gracefully keeps the current model rather
+          // than crashing or silently picking a different price band.
+          expect(picked.id).toBe(current.id);
+        }
+      }
+    }
+  });
+
+  it("never crosses providers, whatever the tier", () => {
+    for (const provider of PROVIDERS) {
+      const current = getDefaultModel(provider);
+      for (const tier of TIERS) {
+        expect(getModelForTier(provider, current.id, tier).provider).toBe(provider);
+      }
+    }
+  });
+
+  it("agrees with getFastModel on the low tier", () => {
+    // getFastModel is now a thin alias; if these ever diverge the refactor
+    // silently changed sub-agent routing.
+    for (const provider of PROVIDERS) {
+      const current = getDefaultModel(provider);
+      expect(getModelForTier(provider, current.id, "low").id).toBe(
+        getFastModel(provider, current.id).id,
+      );
+    }
   });
 });
 

--- a/packages/gg-core/src/model-registry.ts
+++ b/packages/gg-core/src/model-registry.ts
@@ -650,17 +650,35 @@ export function getSummaryModel(provider: Provider, currentModelId: string): Mod
 }
 
 /**
+ * Cheapest sibling within the SAME provider at the requested `costTier`.
+ *
+ * Routes off each model's `costTier` — the single source of truth that already
+ * travels with the registry entry — so a model rename/bump needs no change
+ * here. A provider with no model at that tier gracefully keeps the current
+ * model, so there's never a crash or a cross-provider jump to a login the user
+ * may not have.
+ *
+ * Note: `costTier` is coarse. A provider whose `high` band holds several models
+ * returns the first registry match — pass an explicit model id when one
+ * specific frontier model is required.
+ */
+export function getModelForTier(
+  provider: Provider,
+  currentModelId: string,
+  tier: ModelInfo["costTier"],
+): ModelInfo {
+  const match = getModelsForProvider(provider).find((m) => m.costTier === tier);
+  return match ?? getModel(currentModelId) ?? getDefaultModel(provider);
+}
+
+/**
  * Fastest/cheapest sibling within the SAME provider, for scout-style read-only
  * sub-agents (recon, research) where a low-latency model is enough and the
  * frontier model is wasted spend + latency.
  *
- * Routes off each model's `costTier` — the single source of truth that already
- * travels with the registry entry — so a model rename/bump needs no change
- * here. Providers with no low-tier sibling (GLM, Moonshot, MiniMax, Xiaomi,
- * Sakana, OpenRouter) gracefully keep the parent model, so there's never a
- * crash or a cross-provider jump to a login the user may not have.
+ * Providers with no low-tier sibling (GLM, Moonshot, MiniMax, Xiaomi, Sakana,
+ * OpenRouter) gracefully keep the parent model.
  */
 export function getFastModel(provider: Provider, currentModelId: string): ModelInfo {
-  const low = getModelsForProvider(provider).find((m) => m.costTier === "low");
-  return low ?? getModel(currentModelId) ?? getDefaultModel(provider);
+  return getModelForTier(provider, currentModelId, "low");
 }


### PR DESCRIPTION
## What

`getFastModel` hardcodes a `costTier === "low"` scan that `getSummaryModel` already duplicates. Any other price band — a cheaper execute model for write-capable sub-agents, a stronger model for a verify pass — would mean a third copy of the same find-or-fall-back logic.

This generalises the lookup and reimplements `getFastModel` on top of it:

```ts
export function getModelForTier(
  provider: Provider,
  currentModelId: string,
  tier: ModelInfo["costTier"],
): ModelInfo {
  const match = getModelsForProvider(provider).find((m) => m.costTier === tier);
  return match ?? getModel(currentModelId) ?? getDefaultModel(provider);
}

export function getFastModel(provider: Provider, currentModelId: string): ModelInfo {
  return getModelForTier(provider, currentModelId, "low");
}
```

## Why it is safe

**Pure refactor — no behaviour change.** `getFastModel` keeps identical semantics:

- never crosses providers (the user may only have this one connected),
- falls back to the current model for providers with no sibling in the band (GLM, Moonshot, MiniMax, Xiaomi, Sakana, OpenRouter),
- same fall-back order: `match ?? current ?? provider default`.

No call site changes. `getFastModel`'s signature and every existing test are untouched.

## Tests

Three new cases in `model-registry.test.ts`, driven over **every provider x every tier**:

1. the returned model is in the requested band when the provider has one, otherwise the current model is kept;
2. the result never crosses providers, whatever the tier;
3. low-tier resolution stays byte-identical to `getFastModel` — so if the alias ever diverges, sub-agent routing fails here instead of silently changing spend.

## Verification

- `packages/gg-core`: `tsc --noEmit` clean, **137 tests pass (11 files)**
- `prettier --check` and `eslint` clean on both files
- ggcoder's `getFastModel` consumers re-run green: `subagent-shared.test.ts`, `subagent.test.ts`, `agents.test.ts` — 39 tests pass

## Follow-up (not in this PR)

This unblocks per-role cost tiering (routing write-capable sub-agents to a cheaper band, and a signal-gated verify pass on a stronger one). That work needs reconciling with the existing `AgentModelPreference` (`model: inherit | fast | <id>`) design, so it is deliberately kept out of this PR.