### PR TITLE
feat(ggcoder): let agent model: use a cost tier, not just inherit/fast/<id>

### DIFF
--- a/packages/gg-core/src/model-registry.test.ts
+++ b/packages/gg-core/src/model-registry.test.ts
@@ -13,6 +13,7 @@ import {
   getDefaultModel,
   getDefaultThinkingLevel,
   getFastModel,
+  getModelForTier,
   getModelsForProvider,
   getSummaryModel,
   getToolResultCharLimit,
@@ -111,6 +112,43 @@ describe("getFastModel", () => {
   it("picks Haiku for Anthropic and Luna for OpenAI", () => {
     expect(getFastModel("anthropic", "claude-opus-5").costTier).toBe("low");
     expect(getFastModel("openai", "gpt-5.6-sol").id).toBe("gpt-5.6-luna");
+  });
+});
+
+describe("getModelForTier", () => {
+  const TIERS = ["low", "medium", "high"] as const;
+
+  it("returns a model at the requested tier when the provider has one", () => {
+    for (const provider of PROVIDERS) {
+      const current = getDefaultModel(provider);
+      for (const tier of TIERS) {
+        const picked = getModelForTier(provider, current.id, tier);
+        const hasTier = getModelsForProvider(provider).some((m) => m.costTier === tier);
+        if (hasTier) {
+          expect(picked.costTier).toBe(tier);
+        } else {
+          expect(picked.id).toBe(current.id);
+        }
+      }
+    }
+  });
+
+  it("never crosses providers, whatever the tier", () => {
+    for (const provider of PROVIDERS) {
+      const current = getDefaultModel(provider);
+      for (const tier of TIERS) {
+        expect(getModelForTier(provider, current.id, tier).provider).toBe(provider);
+      }
+    }
+  });
+
+  it("agrees with getFastModel on the low tier", () => {
+    for (const provider of PROVIDERS) {
+      const current = getDefaultModel(provider);
+      expect(getModelForTier(provider, current.id, "low").id).toBe(
+        getFastModel(provider, current.id).id,
+      );
+    }
   });
 });
 

--- a/packages/gg-core/src/model-registry.ts
+++ b/packages/gg-core/src/model-registry.ts
@@ -650,17 +650,35 @@ export function getSummaryModel(provider: Provider, currentModelId: string): Mod
 }
 
 /**
+ * Cheapest sibling within the SAME provider at the requested `costTier`.
+ *
+ * Routes off each model's `costTier` — the single source of truth that already
+ * travels with the registry entry — so a model rename/bump needs no change
+ * here. A provider with no model at that tier gracefully keeps the current
+ * model, so there's never a crash or a cross-provider jump to a login the
+ * user may not have.
+ *
+ * Two real callers, not speculative generality: getFastModel (below) pins
+ * "low", and resolveAgentModel (subagent-shared.ts) passes "medium"/"high"
+ * for the per-role cost-tiering `model:` frontmatter values.
+ */
+export function getModelForTier(
+  provider: Provider,
+  currentModelId: string,
+  tier: ModelInfo["costTier"],
+): ModelInfo {
+  const match = getModelsForProvider(provider).find((m) => m.costTier === tier);
+  return match ?? getModel(currentModelId) ?? getDefaultModel(provider);
+}
+
+/**
  * Fastest/cheapest sibling within the SAME provider, for scout-style read-only
  * sub-agents (recon, research) where a low-latency model is enough and the
  * frontier model is wasted spend + latency.
  *
- * Routes off each model's `costTier` — the single source of truth that already
- * travels with the registry entry — so a model rename/bump needs no change
- * here. Providers with no low-tier sibling (GLM, Moonshot, MiniMax, Xiaomi,
- * Sakana, OpenRouter) gracefully keep the parent model, so there's never a
- * crash or a cross-provider jump to a login the user may not have.
+ * Providers with no low-tier sibling (GLM, Moonshot, MiniMax, Xiaomi, Sakana,
+ * OpenRouter) gracefully keep the parent model.
  */
 export function getFastModel(provider: Provider, currentModelId: string): ModelInfo {
-  const low = getModelsForProvider(provider).find((m) => m.costTier === "low");
-  return low ?? getModel(currentModelId) ?? getDefaultModel(provider);
+  return getModelForTier(provider, currentModelId, "low");
 }

--- a/packages/ggcoder/src/tools/subagent-shared.test.ts
+++ b/packages/ggcoder/src/tools/subagent-shared.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
+import { getDefaultModel, getModelForTier, getModelsForProvider } from "@kenkaiiii/gg-core";
 import type { AgentDefinition } from "../core/agents.js";
 import {
   renderAgentRoster,
   resolveAgentDefinition,
+  resolveAgentModel,
   resolveSubAgentCliEntry,
   selectSubAgent,
   subAgentCacheKey,
@@ -116,5 +118,60 @@ describe("resolveSubAgentCliEntry", () => {
     expect(
       resolveSubAgentCliEntry({ GG_SUBAGENT_WORKER_ENTRY: "/app/error-mom-sidecar.mjs" }),
     ).toBe("/app/error-mom-sidecar.mjs");
+  });
+});
+
+describe("resolveAgentModel — cost tier keywords", () => {
+  const PARENT = "claude-opus-5";
+  const tierId = (provider: Parameters<typeof getModelsForProvider>[0], tier: string) =>
+    getModelsForProvider(provider).find((m) => m.costTier === tier)?.id;
+
+  it("leaves existing preferences byte-identical: unset, inherit, fast, explicit id", () => {
+    expect(resolveAgentModel(undefined, "anthropic", PARENT)).toBe(PARENT);
+    expect(resolveAgentModel(agent({ name: "a" }), "anthropic", PARENT)).toBe(PARENT);
+    expect(resolveAgentModel(agent({ name: "a", model: "inherit" }), "anthropic", PARENT)).toBe(
+      PARENT,
+    );
+    expect(resolveAgentModel(agent({ name: "a", model: "fast" }), "anthropic", PARENT)).toBe(
+      tierId("anthropic", "low"),
+    );
+    expect(
+      resolveAgentModel(agent({ name: "a", model: "claude-sonnet-5" }), "anthropic", PARENT),
+    ).toBe("claude-sonnet-5");
+  });
+
+  it("resolves low/medium/high within the same provider", () => {
+    for (const tier of ["low", "medium", "high"] as const) {
+      expect(resolveAgentModel(agent({ name: "a", model: tier }), "anthropic", PARENT)).toBe(
+        tierId("anthropic", tier),
+      );
+    }
+  });
+
+  it("is case-insensitive", () => {
+    expect(resolveAgentModel(agent({ name: "a", model: "HIGH" }), "anthropic", PARENT)).toBe(
+      tierId("anthropic", "high"),
+    );
+  });
+
+  it("agrees with getModelForTier directly, for every provider", () => {
+    const providers = ["anthropic", "openai", "gemini", "glm", "xai", "moonshot", "local"] as const;
+    for (const provider of providers) {
+      const current = getDefaultModel(provider).id;
+      for (const tier of ["low", "medium", "high"] as const) {
+        expect(resolveAgentModel(agent({ name: "a", model: tier }), provider, current)).toBe(
+          getModelForTier(provider, current, tier).id,
+        );
+      }
+    }
+  });
+
+  it("never crosses providers and never crashes when a tier has no sibling", () => {
+    // gemini has no medium tier registered — must keep the parent model, not
+    // jump to another provider's model or throw.
+    expect(getModelsForProvider("gemini").some((m) => m.costTier === "medium")).toBe(false);
+    expect(
+      resolveAgentModel(agent({ name: "a", model: "medium" }), "gemini", "gemini-3.1-pro-preview"),
+    ).toBe("gemini-3.1-pro-preview");
   });
 });

--- a/packages/ggcoder/src/tools/subagent-shared.ts
+++ b/packages/ggcoder/src/tools/subagent-shared.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import type { Provider, ThinkingLevel } from "@kenkaiiii/gg-ai";
 import type { AgentDefinition } from "../core/agents.js";
-import { getFastModel } from "../core/model-registry.js";
+import { getFastModel, getModelForTier } from "../core/model-registry.js";
 import { truncateTail } from "./truncate.js";
 
 export const SUB_AGENT_MAX_TURNS = 50;
@@ -67,6 +67,12 @@ export function selectSubAgent(
  * research, recon and audit agent always ran on a Haiku-class model, invisibly
  * and with no way to override it. Defaulting to the parent's model instead
  * makes a downgrade opt-in and one line of frontmatter away.
+ *
+ * `model:` accepts, in order: `inherit` (default), `fast` (alias for the
+ * `low` tier), a cost tier keyword (`low` | `medium` | `high`, resolved
+ * within the SAME provider), or an explicit model id passed through
+ * verbatim. A tier keyword is opt-in per agent, same as `fast` always was —
+ * no existing agent's resolved model changes unless its frontmatter says so.
  */
 export function resolveAgentModel(
   agentDef: AgentDefinition | undefined,
@@ -76,6 +82,14 @@ export function resolveAgentModel(
   const preference = agentDef?.model?.trim();
   if (!preference || preference === "inherit") return parentModel;
   if (preference === "fast") return getFastModel(provider, parentModel).id;
+  // A cost tier resolves within the SAME provider, same as `fast` always did
+  // (getFastModel is now `low` under this same mechanism) — no provider jump,
+  // no crash on a provider with no sibling in that band. Anything else is an
+  // explicit model id and passes through verbatim, unchanged from before.
+  const tier = preference.toLowerCase();
+  if (tier === "low" || tier === "medium" || tier === "high") {
+    return getModelForTier(provider, parentModel, tier).id;
+  }
   return preference;
 }
 


### PR DESCRIPTION
Reopens the `getModelForTier` idea from #41, this time attached to the real caller the review asked for.

## What

`model:` in agent frontmatter accepted only `inherit`, `fast` (alias for the low tier), or a literal model id. There was no way to say "run this one tier down from the parent" without hardcoding an id — which silently breaks on a model rename/bump, or points at a model the user isn't logged into after a provider switch.

```ts
export function getModelForTier(
  provider: Provider,
  currentModelId: string,
  tier: ModelInfo["costTier"],
): ModelInfo {
  const match = getModelsForProvider(provider).find((m) => m.costTier === tier);
  return match ?? getModel(currentModelId) ?? getDefaultModel(provider);
}

export function getFastModel(provider: Provider, currentModelId: string): ModelInfo {
  return getModelForTier(provider, currentModelId, "low");
}
```

`resolveAgentModel` now also accepts `low` | `medium` | `high`:

```ts
const tier = preference.toLowerCase();
if (tier === "low" || tier === "medium" || tier === "high") {
  return getModelForTier(provider, parentModel, tier).id;
}
```

## Addressing the #41 close

> `getModelForTier`'s only caller is `getFastModel` with tier `"low"`. Nothing passes `"medium"` or `"high"`

Fixed here: `resolveAgentModel` is the second real caller, passing `"medium"`/`"high"` — the per-role tiering follow-up ships in this same diff.

> The framing said `getSummaryModel` "already duplicates" the logic, but it can't consolidate onto this helper

Dropped. This PR doesn't touch `getSummaryModel` or claim any relation to it.

> reconciled with the existing `AgentModelPreference` (`inherit | fast | <id>`) design

Done — no new `tier:` frontmatter key. `model:` grows three more accepted values inside the field that already exists. `fast` keeps working exactly as before (it's just the `"low"` tier now under the shared mechanism), an explicit model id still passes through verbatim, and no existing agent's resolved model changes unless its frontmatter opts in to a tier keyword.

## Tests

- `model-registry.test.ts`: every provider × every tier — returns the tier when the provider has one, otherwise gracefully keeps the current model; never crosses providers; agrees with `getFastModel` on `"low"`.
- `subagent-shared.test.ts`: `resolveAgentModel` via the same provider × tier matrix, case-insensitivity (`HIGH` → `high`), a no-sibling-tier case (gemini has no `medium`) keeps the parent model, and the existing `inherit`/`fast`/explicit-id paths asserted byte-identical to before.

## Verification

- `gg-core`: `tsc --noEmit` clean, **137/137 tests pass**
- `ggcoder`: `tsc --noEmit` clean, full suite **2517/2536 pass** (17 skipped)
- The 2 failures are pre-existing on `origin/main` without this diff — reproduced identically via `git stash`: a local `~/.bashrc` `shopt` warning breaking a process-gate capture test, and a 15s timing-flaky wake-rule test. Neither touches agent/model resolution.
- `prettier --check` and `eslint` clean on all 4 changed files
