### PR TITLE
Fix two Windows-only CI flakes in background-process tests

### DIFF
--- a/packages/ggcoder/src/core/agent-session-verification-gate.test.ts
+++ b/packages/ggcoder/src/core/agent-session-verification-gate.test.ts
@@ -56,8 +56,11 @@ afterEach(async () => {
   await session?.dispose();
   session = undefined;
   restoreHome?.();
-  await fs.rm(tmpHome, { recursive: true, force: true });
-  await fs.rm(tmpProject, { recursive: true, force: true });
+  // maxRetries: on Windows a just-reaped child's log handle can outlive the
+  // process (background logs live under tmpHome), and a recursive rm then
+  // fails with EBUSY.
+  await fs.rm(tmpHome, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  await fs.rm(tmpProject, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
 });
 
 async function makeSession(): Promise<GateInternals> {
@@ -72,6 +75,29 @@ async function makeSession(): Promise<GateInternals> {
   });
   await session.initialize();
   return session as unknown as GateInternals;
+}
+
+/**
+ * Wait for a background process to genuinely exit.
+ *
+ * A fixed budget is not a substitute: this test's whole claim is that the agent
+ * read a FINISHED run, and `npm test` cold-starts in ~6s on the Windows runner
+ * — past the 5s the old poll loop allowed, after which it silently continued
+ * and asserted against a still-running process. Fail loudly instead.
+ */
+async function waitForExit(
+  manager: ProcessManager,
+  id: string,
+  timeoutMs = 45_000,
+): Promise<number> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const proc = manager.list().find((entry) => entry.id === id);
+    if (!proc) throw new Error(`Background process ${id} disappeared before it exited.`);
+    if (proc.exitCode !== null) return proc.exitCode;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Background process ${id} did not exit within ${timeoutMs}ms.`);
 }
 
 let callSeq = 0;
@@ -159,13 +185,7 @@ describe("AgentSession verification gate", () => {
     // A real short verification-shaped process; it exits non-zero (empty dir),
     // which is fine — the agent SAW the result, that is what counts.
     const started = await manager.start("npm test", tmpProject);
-    for (
-      let i = 0;
-      i < 100 && manager.list().find((p) => p.id === started.id)?.exitCode === null;
-      i += 1
-    ) {
-      await new Promise((resolve) => setTimeout(resolve, 50));
-    }
+    await waitForExit(manager, started.id);
 
     await simulateToolCall(internal, "edit", { file_path: "src/a.ts" });
     await simulateToolCall(internal, "bash", {
@@ -176,7 +196,9 @@ describe("AgentSession verification gate", () => {
 
     await simulateToolCall(internal, "task_output", { id: started.id });
     expect(internal.verificationGate.isOwed()).toBe(false); // read of the finished run
-  });
+    // Longer than the 20s default: the assertion below is about a FINISHED run,
+    // and npm's cold start on the Windows runner is measured in seconds.
+  }, 60_000);
 
   it("is disabled by the verificationGateEnabled setting", async () => {
     const internal = await makeSession();

--- a/packages/ggcoder/src/tools/bash.test.ts
+++ b/packages/ggcoder/src/tools/bash.test.ts
@@ -20,8 +20,42 @@ beforeEach(async () => {
 
 afterEach(async () => {
   restoreHome?.();
-  await fs.rm(tmpHome, { recursive: true, force: true });
+  // maxRetries: Windows releases a dead child's inherited log handle slightly
+  // after the process itself is gone, which surfaces here as EBUSY.
+  await fs.rm(tmpHome, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
 });
+
+/**
+ * A background command that lives briefly and exists everywhere. `sleep` is a
+ * coreutils binary, not a shell builtin, so it is not guaranteed on the Windows
+ * shells `resolveShell` may pick; node is, because the test runner is node.
+ */
+const BRIEF_BACKGROUND_COMMAND = `node -e "setTimeout(() => {}, 500)"`;
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * `shutdownAll()` only signals the process tree and returns. The child can
+ * still hold its log file under `tmpHome` open for a moment after that, and
+ * afterEach's recursive rm then fails with EBUSY on Windows. Wait for the OS to
+ * actually reap what this test started.
+ */
+async function shutdownAndWait(manager: ProcessManager): Promise<void> {
+  const pids = manager.list().map((proc) => proc.pid);
+  manager.shutdownAll();
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (!pids.some(isProcessAlive)) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Background processes still alive after shutdown: ${pids.join(", ")}`);
+}
 
 async function listSavedOutputs(): Promise<string[]> {
   const root = getToolOutputRoot();
@@ -153,7 +187,7 @@ describe("wake-condition validation", () => {
     const tool = createBashTool(tmpHome, manager);
     const result = await tool.execute(
       {
-        command: "sleep 1",
+        command: BRIEF_BACKGROUND_COMMAND,
         run_in_background: true,
         wake: { pattern: "READY", silence_seconds: 30 },
       },
@@ -161,7 +195,7 @@ describe("wake-condition validation", () => {
     );
     expect(String(result)).toContain("Wake rules armed");
     expect(String(result)).toContain("silence 30s");
-    await manager.shutdownAll();
+    await shutdownAndWait(manager);
   });
 
   it("does not promise a wake when no notification path exists", async () => {
@@ -169,12 +203,12 @@ describe("wake-condition validation", () => {
     const manager = new ProcessManager({ bgDir: `${tmpHome}/bg-noqueue` });
     const tool = createBashTool(tmpHome, manager);
     const result = await tool.execute(
-      { command: "sleep 1", run_in_background: true, wake: { pattern: "READY" } },
+      { command: BRIEF_BACKGROUND_COMMAND, run_in_background: true, wake: { pattern: "READY" } },
       { signal: new AbortController().signal, toolCallId: "wake-4" },
     );
     expect(String(result)).toContain("NOT armed");
     expect(String(result)).toContain("Poll task_output");
-    await manager.shutdownAll();
+    await shutdownAndWait(manager);
   });
 });
 


### PR DESCRIPTION
Both failures were in the test harness, not the code under test. Neither is reproducible on macOS/Linux, which is why they only ever surfaced on the blocking Windows gate.

### `agent-session-verification-gate.test.ts`
The test polled 5s for a real `npm test` to exit, then **continued regardless**. npm cold-starts in ~6.2s on the Windows runner, so the assertion about a *finished* run was made against a still-running process (`expected true to be false`).

Now waits on actual exit and throws on timeout. Test budget raised to 60s since the assertion is specifically about a completed run.

### `bash.test.ts`
Two problems:
- `sleep 1` is a coreutils binary, not a shell builtin — not guaranteed on the Windows shell `resolveShell` picks. Replaced with `node -e`, which is guaranteed because the test runner is node.
- The actual observed failure was `EBUSY: resource busy or locked, rmdir`. `shutdownAll()` signals the process tree and returns immediately, but Windows can still hold the child's inherited log handle open when `afterEach`'s recursive `rm` runs. Added `shutdownAndWait()` to wait for reaping, plus `maxRetries` on `fs.rm` — the same pattern already used in `subagent-manager.test.ts` and `process-manager-notifications.test.ts`.

### These tests were not weakened
- **No `expect(` lines changed** in either file.
- **Mutation-checked**: disabling the `task_output` branch in `agent-session.ts` makes the gate test fail; restoring it makes it pass. It still catches real regressions.
- The old code was the lax one — a 5s budget that silently proceeded on timeout. Both new waits throw.
- Local: 3 consecutive clean runs, typecheck and lint pass.

**Windows CI on this PR is the real proof** — the root causes are Windows-only, so a green macOS run does not demonstrate the fix.