### PR TITLE
Fix restored sessions failing to open when the network is unreachable

### DIFF
--- a/packages/ggcoder/src/core/agent-session-compaction.test.ts
+++ b/packages/ggcoder/src/core/agent-session-compaction.test.ts
@@ -1431,4 +1431,46 @@ describe("load-time auto-compaction deferral (deferLoadCompaction)", () => {
     expect(compactMock).toHaveBeenCalledTimes(1);
     await resumed.dispose();
   });
+
+  // Regression: the credentials resolved on this path only SIZE the context
+  // window, but an expired OAuth token makes resolving them refresh over the
+  // network. With no connectivity the refresh rejected ("fetch failed"),
+  // initialize() rejected with it, the gg-app's session creation failed, and
+  // the window — which therefore never received a port — reported "sidecar did
+  // not start in time" after 30s.
+  it("opens a restored session when the credential refresh cannot reach the network", async () => {
+    const sessionPath = await persistSession();
+
+    // Expire the stored credential so resolution must refresh over the network.
+    const authPath = path.join(tmpHome, ".gg", "auth.json");
+    const auth = JSON.parse(await fs.readFile(authPath, "utf-8")) as Record<
+      string,
+      { expiresAt: number }
+    >;
+    auth["anthropic"]!.expiresAt = Date.now() - 60_000;
+    await writeJson(authPath, auth);
+
+    shouldCompactMock.mockReturnValue(true);
+    compactMock.mockResolvedValue(compactedResult);
+    const offline = vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("fetch failed"));
+
+    try {
+      const { AgentSession } = await import("./agent-session.js");
+      const resumed = new AgentSession({
+        provider: "anthropic",
+        model: "claude-test",
+        cwd: tmpProject,
+        systemPrompt: "system prompt",
+        sessionId: sessionPath,
+      });
+
+      await expect(resumed.initialize()).resolves.toBeUndefined();
+      // Compacting needs a live provider call, so it waits for the first prompt
+      // instead of failing the restore.
+      expect(compactMock).not.toHaveBeenCalled();
+      await resumed.dispose();
+    } finally {
+      offline.mockRestore();
+    }
+  });
 });

--- a/packages/ggcoder/src/core/agent-session.ts
+++ b/packages/ggcoder/src/core/agent-session.ts
@@ -27,7 +27,7 @@ import { PROMPT_COMMANDS, getPromptCommand } from "./prompt-commands.js";
 import { loadCustomCommands } from "./custom-commands.js";
 import { SettingsManager } from "./settings-manager.js";
 import { AuthStorage } from "./auth-storage.js";
-import { dualAuthProvider } from "@kenkaiiii/gg-core";
+import { dualAuthProvider, type OAuthCredentials } from "@kenkaiiii/gg-core";
 import { getClaudeCliUserAgent } from "./claude-code-version.js";
 import { kimiCodingHeaders, isKimiCodingEndpoint } from "./oauth/kimi.js";
 import { isGrokCliEndpoint } from "./oauth/xai.js";
@@ -3551,16 +3551,38 @@ export class AgentSession {
     }
     // Auto-compact on load if the restored session exceeds the context window.
     // Without this, huge sessions (1M+ tokens) get loaded into memory and OOM.
-    const creds = await this.authStorage.resolveCredentials(this.provider, {
-      storageKeys: this.currentAuthStorageKeys(),
-    });
+    //
+    // These credentials only SIZE the context window here — but an expired
+    // OAuth token makes resolving them refresh over the network, and restoring
+    // a window awaits this method. Offline, that refresh rejects with "fetch
+    // failed", session creation fails, the window never receives a port, and
+    // its UI blames the sidecar for never starting. A transport failure must
+    // not decide whether a session can open: degrade to no account context and
+    // leave credentials to the first prompt, which needs them for real and can
+    // report a failure honestly.
+    let creds: OAuthCredentials | undefined;
+    try {
+      creds = await this.authStorage.resolveCredentials(this.provider, {
+        storageKeys: this.currentAuthStorageKeys(),
+      });
+    } catch (err) {
+      log(
+        "WARN",
+        "session",
+        "Restore credential resolution failed — opening without account context",
+        {
+          provider: this.provider,
+          message: err instanceof Error ? err.message : String(err),
+        },
+      );
+    }
     // Cache for sync callers (see field doc) so the app-sidecar's footer shows
     // the right context window immediately on resume, before any prompt runs
     // runLoop() and would otherwise be the first to set this.
-    this.lastAccountId = creds.accountId;
+    this.lastAccountId = creds?.accountId;
     const contextWindow = getContextWindow(this.model, {
       provider: this.provider,
-      accountId: creds.accountId,
+      accountId: creds?.accountId,
     });
     this.sessionId = loaded.header.id;
     this.setSessionPath(loaded.path);
@@ -3571,13 +3593,13 @@ export class AgentSession {
       model: this.model,
       contextWindow,
       threshold: this.settingsManager.get("compactThreshold"),
-      accountId: creds.accountId,
+      accountId: creds?.accountId,
       approvedPlanPath: this.approvedPlanPath,
     });
     log("INFO", "compaction", "Restore compaction decision", {
       provider: this.provider,
       model: this.model,
-      transport: this.provider === "openai" && creds.accountId ? "codex_oauth" : "public_api",
+      transport: this.provider === "openai" && creds?.accountId ? "codex_oauth" : "public_api",
       contextWindow: String(contextWindow),
       activeTokens: "estimated",
       triggerLimit: String(loadPolicy.targetTokens),
@@ -3585,7 +3607,9 @@ export class AgentSession {
     const needsLoadCompaction =
       this.settingsManager.get("autoCompact") &&
       shouldCompact(this.messages, contextWindow, loadPolicy.threshold);
-    if (needsLoadCompaction && this.opts.deferLoadCompaction) {
+    // Compacting needs a live provider call, so an unresolved credential
+    // defers it to the first prompt rather than attempting it here.
+    if (needsLoadCompaction && (this.opts.deferLoadCompaction || !creds)) {
       // Canonicalize again immediately before the first prompt is persisted:
       // another process may create the shared checkpoint after this load.
       this.deferredCompactionPending = true;
@@ -3594,7 +3618,7 @@ export class AgentSession {
         "session",
         "Restored session exceeds context — deferring compaction to first prompt",
       );
-    } else if (needsLoadCompaction) {
+    } else if (needsLoadCompaction && creds) {
       await this.subAgentManager?.hydrate(loaded.header.id);
       log("INFO", "session", `Restored session exceeds context — auto-compacting`);
       await this.compact(creds, "automatic");


### PR DESCRIPTION
## The bug

A restored window sometimes fails with:

```
✻ agent failed to start: sidecar did not start in time
```

The message is misleading — the sidecar is already listening. Chain:

1. Restoring a window calls `AgentSession.loadExistingSession()`, which resolves OAuth credentials purely to learn the account's context window for the compaction decision.
2. With an expired token that resolution refreshes over the network. On a dropped or flaky link it rejects with `TypeError: fetch failed`.
3. Nothing on that path catches it — `initialize()` rejects and `POST /session` answers `500 {"error":"fetch failed"}`.
4. The Rust shell logs `daemon session creation failed` and never retries, so `sidecar_port()` keeps returning `None` for that window (it only reports a port once *that* window has a session).
5. The webview's `waitForReady()` polls for 30 s, then throws `sidecar did not start in time`.

Only restarting the app, with working connectivity, recovers the window. Observed on 0.53.12 with two of four restored windows after a brief network drop.

## The fix

A credential refresh that fails for transport reasons must not decide whether a session can open. On this path `creds` feeds only `accountId` (context-window sizing and compaction policy), so an unreachable refresh degrades to "no account context" and leaves credentials to the first prompt — which needs them for real and can report a failure honestly.

Compaction itself needs a live provider call, so an unresolved credential defers it to that first prompt (the existing `deferLoadCompaction` path) rather than attempting it during restore.

Genuine auth failures are unaffected: a revoked refresh token still raises `NotLoggedInError` on the first prompt through the ordinary run path.

## Test

`packages/ggcoder/src/core/agent-session-compaction.test.ts` gains a regression test that persists a real session, expires the stored credential, makes `fetch` reject with `TypeError("fetch failed")`, and asserts the restore still opens with compaction deferred.

Verified red/green: the test fails with `AssertionError: promise rejected "TypeError: fetch failed" instead of resolving` on `main`, and passes with this change.

- `pnpm --filter @kenkaiiii/ggcoder check` — clean
- `pnpm vitest run src/core` — 1582 passed. Three failures (`sandbox.test.ts`, `process-manager-wake.test.ts`, `agent-session-process-gate.test.ts`) reproduce identically on unmodified `main` in this environment and are unrelated.
- eslint + prettier clean on both changed files.
